### PR TITLE
When getting started page is viewed as view user, do not show create container block

### DIFF
--- a/Controller.php
+++ b/Controller.php
@@ -82,7 +82,12 @@ class Controller extends \Piwik\Plugin\Controller
     public function gettingStarted()
     {
         Piwik::checkUserHasSomeViewAccess();
-        return $this->renderTemplate('gettingStarted');
+
+        $canEdit = $this->accessValidator->hasWritePermission($this->idSite);
+
+        return $this->renderTemplate('gettingStarted', array(
+            'canEdit' => $canEdit
+        ));
     }
 
     public function manageTags()

--- a/Input/AccessValidator.php
+++ b/Input/AccessValidator.php
@@ -25,6 +25,16 @@ class AccessValidator
         Piwik::checkUserHasAdminAccess($idSite);
     }
 
+    public function hasWritePermission($idSite)
+    {
+        try {
+            $this->checkWritePermission($idSite);
+        } catch (\Exception $e) {
+            return false;
+        }
+        return true;
+    }
+
     public function checkSiteExists($idSite)
     {
         new Site($idSite);

--- a/templates/gettingStarted.twig
+++ b/templates/gettingStarted.twig
@@ -49,14 +49,17 @@
         </p>
 
     </div>
+
+    {% if canEdit %}
     <div piwik-content-block content-title="How do I get started?">
         <p>If you haven't created a container yet, <a href="{{ linkTo({module: 'TagManager', 'action': 'manageContainers'}) }}#?idContainer=0">create a container now</a>. Next you need to copy/paste the code for the container into your website, this is a simple HTML snippet. From this point, this code will
             load all other snippets and you usually won't need to make any changes to your website anymore.
             <br /><br />
             Now you can add one or multiple tags to your container. If you have embedded a tag manually into your site in the past, you should at the same time also remove all previously added snippets from your website as they will be then loaded through the tag manager.
         </p>
-
     </div>
+    {% endif %}
+
     <div piwik-content-block content-title="What if a tag, trigger, or variable I need is not supported yet?">
         <p>
             There are custom tags, triggers, and variables available to let you implement pretty much any use case you need.

--- a/tests/Integration/Input/AccessValidatorTest.php
+++ b/tests/Integration/Input/AccessValidatorTest.php
@@ -90,6 +90,29 @@ class AccessValidatorTest extends IntegrationTestCase
         $this->validator->checkSiteExists($idSite = 999);
     }
 
+    public function test_hasWritePermission_anonymousWithoutViewCannot()
+    {
+        $this->setAnonymous();
+        $this->assertFalse($this->validator->hasWritePermission($idSite = 1));
+    }
+
+    public function test_hasWritePermission_success_user()
+    {
+        $this->setUser();
+        $this->assertFalse($this->validator->hasWritePermission($idSite = 1));
+    }
+
+    public function test_hasWritePermission_admin()
+    {
+        $this->setAdmin();
+        $this->assertTrue($this->validator->hasWritePermission($idSite = 1));
+    }
+
+    public function test_hasWritePermission_success_Superuser()
+    {
+        $this->assertTrue($this->validator->hasWritePermission($idSite = 1));
+    }
+
     protected function setAnonymous()
     {
         FakeAccess::clearAccess(false);


### PR DESCRIPTION
As view user won't be able to follow these instructions.