### PR TITLE
Add Facebook Pixel Tag Type to Matomo Tag Manager

### DIFF
--- a/Template/Tag/FacebookPixelTag.php
+++ b/Template/Tag/FacebookPixelTag.php
@@ -34,6 +34,11 @@ class FacebookPixelTag extends BaseTag
         return self::CATEGORY_ANALYTICS;
     }
 
+    public function getIcon()
+    {
+        return 'plugins/TagManager/images/icons/F_icon.svg';
+    }
+
     public function getParameters()
     {
         return array(

--- a/Template/Tag/FacebookPixelTag.php
+++ b/Template/Tag/FacebookPixelTag.php
@@ -29,7 +29,7 @@ class FacebookPixelTag extends BaseTag
 
     public function getDescription()
     {
-        return 'The Facebook Pixel is a web analytics and avertising service offered by Facebook.';
+        return 'The Facebook Pixel is a web analytics and advertising service offered by Facebook.';
     }
 
     public function getHelp()

--- a/Template/Tag/FacebookPixelTag.php
+++ b/Template/Tag/FacebookPixelTag.php
@@ -42,15 +42,10 @@ class FacebookPixelTag extends BaseTag
     public function getParameters()
     {
         return array(
-            $this->makeSetting('pixelId', '', FieldConfig::TYPE_STRING, function (FieldConfig $field) {
+            $this->makeSetting('pixelId',, FieldConfig::TYPE_STRING, function (FieldConfig $field) {
                 $field->title = 'Pixel ID';
                 $field->description = 'Long numerical number for Facebook Pixel Code"';
-                $field->validators[] = new NotEmpty();
-                $field->validate = function ($value) {
-                    if (!preg_match('^\d+$', strval($value))) {
-                        throw new \Exception('The Pixel ID should only contain a series of numbers.');
-                    }
-                };
+                $field->validators[] = new NumberRange($min = 0);
             }),
             $this->makeSetting('trackingType', 'pageview', FieldConfig::TYPE_STRING, function (FieldConfig $field) {
                 $field->title = 'Tracking Type';

--- a/Template/Tag/FacebookPixelTag.php
+++ b/Template/Tag/FacebookPixelTag.php
@@ -10,11 +10,19 @@ namespace Piwik\Plugins\TagManager\Template\Tag;
 use Piwik\Settings\FieldConfig;
 use Piwik\Plugins\TagManager\Template\Tag\BaseTag;
 use Piwik\Validators\NotEmpty;
+use Piwik\Validators\NumberRange;
 
 class FacebookPixelTag extends BaseTag
 {
 
-    Public function getName()
+    const ID = 'FacebookPixel';
+
+    public function getId()
+    {
+        return self::ID;
+    }
+
+    public function getName()
     {
         return 'Facebook Pixel';
     }
@@ -26,12 +34,7 @@ class FacebookPixelTag extends BaseTag
 
     public function getHelp()
     {
-        return 'This tag lets you track website pageviews in your Facebook Ads account. To obtain the  Pixel ID please log in to your Facebook Ads account.';
-    }
-
-    public function getCategory()
-    {
-        return self::CATEGORY_ANALYTICS;
+        return 'This tag lets you track website pageviews in your Facebook Ads account. To obtain the Pixel ID please log in to your Facebook Ads account.';
     }
 
     public function getIcon()
@@ -42,10 +45,9 @@ class FacebookPixelTag extends BaseTag
     public function getParameters()
     {
         return array(
-            $this->makeSetting('pixelId',, FieldConfig::TYPE_STRING, function (FieldConfig $field) {
+            $this->makeSetting('pixelId', '', FieldConfig::TYPE_INT, function (FieldConfig $field) {
                 $field->title = 'Pixel ID';
-                $field->description = 'Long numerical number for Facebook Pixel Code"';
-                $field->validators[] = new NumberRange($min = 0);
+                $field->validators[] = new NumberRange();
             }),
             $this->makeSetting('trackingType', 'pageview', FieldConfig::TYPE_STRING, function (FieldConfig $field) {
                 $field->title = 'Tracking Type';
@@ -55,8 +57,13 @@ class FacebookPixelTag extends BaseTag
                 $field->availableValues = array(
                     'pageview' => 'Pageview',
                 );
-            })
-    );
+            }),
+        );
+    }
+
+    public function getCategory()
+    {
+        return self::CATEGORY_SOCIAL;
     }
 
 }

--- a/Template/Tag/FacebookPixelTag.php
+++ b/Template/Tag/FacebookPixelTag.php
@@ -1,4 +1,3 @@
-
 <?php
 /**
  * Matomo - free/libre analytics platform

--- a/Template/Tag/FacebookPixelTag.php
+++ b/Template/Tag/FacebookPixelTag.php
@@ -1,0 +1,63 @@
+
+<?php
+/**
+ * Matomo - free/libre analytics platform
+ *
+ * @link https://matomo.org
+ * @license http://www.gnu.org/licenses/gpl-3.0.html GPL v3 or later
+ */
+namespace Piwik\Plugins\TagManager\Template\Tag;
+
+use Piwik\Settings\FieldConfig;
+use Piwik\Plugins\TagManager\Template\Tag\BaseTag;
+use Piwik\Validators\NotEmpty;
+
+class FacebookPixelTag extends BaseTag
+{
+
+    Public function getName()
+    {
+        return 'Facebook Pixel';
+    }
+
+    public function getDescription()
+    {
+        return 'The Facebook Pixel is a web analytics and avertising service offered by Facebook.';
+    }
+
+    public function getHelp()
+    {
+        return 'This tag lets you track website pageviews in your Facebook Ads account. To obtain the  Pixel ID please log in to your Facebook Ads account.';
+    }
+
+    public function getCategory()
+    {
+        return self::CATEGORY_ANALYTICS;
+    }
+
+    public function getParameters()
+    {
+        return array(
+            $this->makeSetting('pixelId', '', FieldConfig::TYPE_STRING, function (FieldConfig $field) {
+                $field->title = 'Pixel ID';
+                $field->description = 'Long numerical number for Facebook Pixel Code"';
+                $field->validators[] = new NotEmpty();
+                $field->validate = function ($value) {
+                    if (!preg_match('^\d+$', strval($value))) {
+                        throw new \Exception('The Pixel ID should only contain a series of numbers.');
+                    }
+                };
+            }),
+            $this->makeSetting('trackingType', 'pageview', FieldConfig::TYPE_STRING, function (FieldConfig $field) {
+                $field->title = 'Tracking Type';
+                $field->description = 'Only the tracking type "Pageview" is currently supported.';
+                $field->uiControl = FieldConfig::UI_CONTROL_SINGLE_SELECT;
+                $field->validators[] = new NotEmpty();
+                $field->availableValues = array(
+                    'pageview' => 'Pageview',
+                );
+            })
+    );
+    }
+
+}

--- a/Template/Tag/FacebookPixelTag.web.js
+++ b/Template/Tag/FacebookPixelTag.web.js
@@ -18,7 +18,7 @@
             var pixelId = parameters.get('pixelId');
             if (!(pixelId in setup)) {
                 setup[pixelId] = true;
-                fbq('init', parameters.get('pixelId'));
+                fbq('init', pixelId);
             }
 
             fbq('track', 'PageView');

--- a/Template/Tag/FacebookPixelTag.web.js
+++ b/Template/Tag/FacebookPixelTag.web.js
@@ -1,0 +1,27 @@
+(function () {
+    return function (parameters, TagManager) {
+        var setup = {};
+        var isLibLoaded = false;
+        this.fire = function () {
+            if (!isLibLoaded) {
+                isLibLoaded = true;
+                !function(f,b,e,v,n,t,s)
+                {if(f.fbq)return;n=f.fbq=function(){n.callMethod?
+                n.callMethod.apply(n,arguments):n.queue.push(arguments)};
+                if(!f._fbq)f._fbq=n;n.push=n;n.loaded=!0;n.version='2.0';
+                n.queue=[];t=b.createElement(e);t.async=!0;
+                t.src=v;s=b.getElementsByTagName(e)[0];
+                s.parentNode.insertBefore(t,s)}(parameters.window,parameters.document,'script',
+                'https://connect.facebook.net/en_US/fbevents.js');
+            }
+
+            var pixelId = parameters.get('pixelId');
+            if (!(pixelId in setup)) {
+                setup[pixelId] = true;
+                fbq('init', parameters.get('pixelId'));
+            }
+
+            fbq('track', 'PageView');
+        };
+    };
+})();

--- a/images/icons/F_icon.svg
+++ b/images/icons/F_icon.svg
@@ -1,6 +1,10 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <!DOCTYPE svg PUBLIC "-//W3C//DTD SVG 1.1//EN" "http://www.w3.org/Graphics/SVG/1.1/DTD/svg11.dtd">
 <svg width="100%" height="100%" viewBox="0 0 64 64" version="1.1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" xml:space="preserve" xmlns:serif="http://www.serif.com/" style="fill-rule:evenodd;clip-rule:evenodd;stroke-linejoin:round;stroke-miterlimit:1.41421;">
+    <!-- 
+    Source: https://commons.wikimedia.org/wiki/File:F_icon.svg (public domain)
+    Facebook is a registered Trademark and this logo may be protected. For more information see https://en.facebookbrand.com/
+    -->
     <g id="Blue_1_" transform="matrix(0.239796,0,0,0.239795,0,0)">
         <path d="M248.082,262.307C255.936,262.307 262.305,255.938 262.305,248.082L262.305,18.812C262.305,10.955 255.937,4.588 248.082,4.588L18.812,4.588C10.955,4.588 4.588,10.955 4.588,18.812L4.588,248.082C4.588,255.937 10.954,262.307 18.812,262.307L248.082,262.307Z" style="fill:rgb(60,90,153);fill-rule:nonzero;"/>
     </g>

--- a/images/icons/F_icon.svg
+++ b/images/icons/F_icon.svg
@@ -1,0 +1,10 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<!DOCTYPE svg PUBLIC "-//W3C//DTD SVG 1.1//EN" "http://www.w3.org/Graphics/SVG/1.1/DTD/svg11.dtd">
+<svg width="100%" height="100%" viewBox="0 0 64 64" version="1.1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" xml:space="preserve" xmlns:serif="http://www.serif.com/" style="fill-rule:evenodd;clip-rule:evenodd;stroke-linejoin:round;stroke-miterlimit:1.41421;">
+    <g id="Blue_1_" transform="matrix(0.239796,0,0,0.239795,0,0)">
+        <path d="M248.082,262.307C255.936,262.307 262.305,255.938 262.305,248.082L262.305,18.812C262.305,10.955 255.937,4.588 248.082,4.588L18.812,4.588C10.955,4.588 4.588,10.955 4.588,18.812L4.588,248.082C4.588,255.937 10.954,262.307 18.812,262.307L248.082,262.307Z" style="fill:rgb(60,90,153);fill-rule:nonzero;"/>
+    </g>
+    <g id="f" transform="matrix(0.239796,0,0,0.239795,0,0)">
+        <path d="M182.409,262.307L182.409,162.504L215.908,162.504L220.924,123.609L182.409,123.609L182.409,98.777C182.409,87.516 185.536,79.842 201.684,79.842L222.28,79.833L222.28,45.045C218.718,44.571 206.492,43.512 192.268,43.512C162.573,43.512 142.243,61.638 142.243,94.925L142.243,123.609L108.658,123.609L108.658,162.504L142.243,162.504L142.243,262.307L182.409,262.307Z" style="fill:white;fill-rule:nonzero;"/>
+    </g>
+</svg>


### PR DESCRIPTION
Attempting to create an interface for adding Facebook Pixels Tags. Based on default Google Analytics tag and proposed Google AdWords Tag. 

Note: Tested on a live server and it doesn’t appear to add the section of Tags available? I know this product is new so documentation is light but I’m wondering if there is a missing ingredient for it to show up?

Disclaimer: "Facebook" is a registered trademark of Facebook, Inc. I am not officially partnered with, authorized, endorsed, or sponsored by Facebook. I believe this falls under “General” acceptable use as defined in [Facebook Brand Guidelines](https://en.facebookbrand.com/guidelines/brand) but I’m happy to remove/modify if not.