### PR TITLE
add Zendesk Chat Tag

### DIFF
--- a/Template/Tag/ZendeskChatTag.php
+++ b/Template/Tag/ZendeskChatTag.php
@@ -1,0 +1,45 @@
+<?php
+/**
+ * Matomo - free/libre analytics platform
+ *
+ * @link https://matomo.org
+ * @license http://www.gnu.org/licenses/gpl-3.0.html GPL v3 or later
+ */
+
+namespace Piwik\Plugins\TagManager\Template\Tag;
+
+use Piwik\Settings\FieldConfig;
+use Piwik\Plugins\TagManager\Template\Tag\BaseTag;
+use Piwik\Settings\Setting;
+use Piwik\Validators\CharacterLength;
+use Piwik\Validators\NotEmpty;
+use Piwik\Validators\NumberRange;
+
+class ZendeskChatTag extends BaseTag
+{
+    public function getCategory() {
+        return self::CATEGORY_SOCIAL;
+    }
+
+    public function getIcon() {
+        return 'plugins/TagManager/images/icons/zendesk_chat.svg';
+    }
+
+    public function getParameters() {
+        return array(
+            $this->makeSetting('zendeskChatId', '', FieldConfig::TYPE_STRING, function (FieldConfig $field) {
+                $field->title = 'Zendesk Chat ID';
+                $field->description = 'You can get the Site ID by logging into Zendesk Chat, going to "Settings" and clicking on "Widget". The Site ID has typically about 32 characters and is the text coming directly after "https://v2.zopim.com/?", for example "123451c27295ad739e46b6b1".';
+                $field->validators[] = new NotEmpty();
+                $field->validators[] = new CharacterLength(20, 40);
+                $field->validate = function ($value, Setting $setting) {
+                    if (substr($value, 0, 1) === "?") {
+                        throw new \Exception("The Chat ID shouldn't include the staring '?'");
+                    }
+                };
+
+            }),
+        );
+    }
+
+}

--- a/Template/Tag/ZendeskChatTag.web.js
+++ b/Template/Tag/ZendeskChatTag.web.js
@@ -1,0 +1,25 @@
+(function () {
+    return function (parameters, TagManager) {
+        this.fire = function () {
+            var zendeskChatId = parameters.get("zendeskChatId");
+            window.$zopim || (function () {
+                var z = $zopim = function (c) {
+                    z._.push(c)
+                };
+                var script = z.s = document.createElement("script");
+                var e = document.getElementsByTagName("script")[0];
+                z.set = function (o) {
+                    z.set._.push(o)
+                };
+                z._ = [];
+                z.set._ = [];
+                script.async = true;
+                script.setAttribute("charset", "utf-8");
+                script.src = "https://v2.zopim.com/?" + zendeskChatId;
+                z.t = +new Date;
+                script.type = "text/javascript";
+                e.parentNode.insertBefore(script, e)
+            })();
+        };
+    };
+})();

--- a/images/icons/zendesk_chat.svg
+++ b/images/icons/zendesk_chat.svg
@@ -1,0 +1,5 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="73" height="58.6">
+    <!-- Source: https://d1eipm3vz40hy0.cloudfront.net/images/p-legal/icon-chat.svg -->
+    <path d="M25.5 7.3l.1.1a36.2 36.2 0 0 1 0 51.2L0 32.8z" fill="#f79a3e"/>
+    <path d="M54.8 36.6l-.1-.1a25.8 25.8 0 0 1 0-36.5L73 18.3z" fill="#00363d"/>
+</svg>

--- a/lang/en.json
+++ b/lang/en.json
@@ -489,6 +489,9 @@
       "WindowLoadedTriggerName": "Window Loaded",
       "WindowUnloadTriggerDescription": "Triggered just before the browser window is closed or when the user navigates to a different page.",
       "WindowUnloadTriggerHelp": "This trigger identifies the event when a user is actually closing the current page compared to the \"Window Leave\" trigger which triggers when the user is about to leave your page. Either by navigating to another page within the current browser tab, or by completely closing the tab.",
-      "WindowUnloadTriggerName": "Window Unload"
+      "WindowUnloadTriggerName": "Window Unload",
+      "ZendeskChatTagDescription": "Reach your customers, instantly via web, mobile, and messaging.",
+      "ZendeskChatTagHelp": "This tag allows you to add the Zendesk Chat form to your website.",
+      "ZendeskChatTagName": "Zendesk Chat (formerly Zopim)"
    }
 }


### PR DESCRIPTION
Works in my quick test and is pretty straight forward. 

Unfortunately there is no nice way to copy the ID.

The widget looks like this:
```html
<!--Start of Zendesk Chat Script-->
<script type="text/javascript">
    window.$zopim||(function(d,s){var z=$zopim=function(c){z._.push(c)},$=z.s=
        d.createElement(s),e=d.getElementsByTagName(s)[0];z.set=function(o){z.set.
    _.push(o)};z._=[];z.set._=[];$.async=!0;$.setAttribute("charset","utf-8");
        $.src="https://v2.zopim.com/?5vsZG8Jx0J9FS85qxc6Xn5MMIfVBDzML";z.t=+new Date;$.
            type="text/javascript";e.parentNode.insertBefore($,e)})(document,"script");
</script>
<!--End of Zendesk Chat Script-->
```

I tried to de-minimize it a bit to make it more readable.