### PR TITLE
remove license badge from readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,6 @@
 # Free Open Source Matomo Tag Manager
 
 [![Build Status](https://travis-ci.org/matomo-org/tag-manager.svg?branch=master)](https://travis-ci.org/matomo-org/tag-manager)
-[![License](https://poser.pugx.org/matomo-org/tag-manager/license)](https://matomo.org/free-software/)
 
 ## Description
 


### PR DESCRIPTION
`poser.pugx.org` only seems to work with packagist packages, so it doesn't make sense to link it.

PS: We should maybe link to https://plugins.matomo.org/TagManager in the header.