### PR TITLE
Create directory if it doesn't exist yet when writing container

### DIFF
--- a/Context/Storage/Filesystem.php
+++ b/Context/Storage/Filesystem.php
@@ -21,6 +21,7 @@ class Filesystem implements StorageInterface
 
         if (!isset($content) || $content !== $data) {
             // we only want to save the file when needed
+            \Piwik\Filesystem::mkdir(dirname($name));
             file_put_contents($name, $data);
 
             /**


### PR DESCRIPTION
The directory might not exist if a custom directory is configured.