### PR TITLE
Add option to bundle Matomo in container directly

### DIFF
--- a/TagManager.php
+++ b/TagManager.php
@@ -51,6 +51,7 @@ class TagManager extends \Piwik\Plugin
             'TagManager.regenerateContainerReleases' => 'regenerateReleasedContainers',
             'Updater.componentUpdated' => 'regenerateReleasedContainers',
             'Controller.CoreHome.checkForUpdates.end' => 'regenerateReleasedContainers',
+            'CustomPiwikJs.piwikJsChanged' => 'regenerateReleasedContainers', // in case a Matomo tracker is bundled
             'SitesManager.deleteSite.end' => 'onSiteDeleted',
             'SitesManager.addSite.end' => 'onSiteAdded',
             'System.addSystemSummaryItems' => 'addSystemSummaryItems',

--- a/Template/Tag/MatomoTag.php
+++ b/Template/Tag/MatomoTag.php
@@ -7,6 +7,7 @@
  */
 namespace Piwik\Plugins\TagManager\Template\Tag;
 
+use Piwik\Container\StaticContainer;
 use Piwik\Settings\FieldConfig;
 use Piwik\Validators\CharacterLength;
 use Piwik\Validators\NotEmpty;
@@ -16,6 +17,7 @@ class MatomoTag extends BaseTag
 {
     const ID = 'Matomo';
     const PARAM_MATOMO_CONFIG = 'matomoConfig';
+    const REPLACE_TRACKER_KEY = "var replaceMeWithTracker='';";
 
     public function getId()
     {
@@ -108,6 +110,17 @@ class MatomoTag extends BaseTag
                 $field->validate = function (){}; // prevent executing default float validator which requires a value, value here is optional
             })
         );
+    }
+
+    public function loadTemplate($context, $entity)
+    {
+        $template = parent::loadTemplate($context, $entity);
+        if ($template && !empty($entity['parameters']['matomoConfig']['parameters']['bundleTracker'])) {
+            $trackerUpdater = StaticContainer::get('Piwik\Plugins\CustomPiwikJs\TrackerUpdater');
+            $tracker = $trackerUpdater->getUpdatedTrackerFileContent();
+            return str_replace(self::REPLACE_TRACKER_KEY, $tracker, $template);
+        }
+        return $template;
     }
 
     public function getOrder()

--- a/Template/Tag/MatomoTag.web.js
+++ b/Template/Tag/MatomoTag.web.js
@@ -1,4 +1,5 @@
 (function () {
+
     var libLoaded = false;
     var libAvailable = false;
     var callbacks = {
@@ -26,6 +27,12 @@
             callbacks.callbacks[i]();
         }
     });
+
+    function loadMatomo() {
+        var replaceMeWithTracker=''; // do not modify this line, be replaced with Matomo tracker. Cannot use /*!! comment because of Jshrink bug
+        libAvailable = true;
+        libLoaded = true;
+    }
 
     function loadTracker(url)
     {
@@ -84,7 +91,7 @@
                     lastIdSite = matomoConfig.idSite;
                     // but even two or more different configs for the same Matomo URL & idSite
                     lastMatomoUrl = getMatomoUrlFromConfig(matomoConfig);
-                    var trackerUrl = matomoUrl + 'piwik.php';
+                    var trackerUrl = lastMatomoUrl + 'piwik.php';
                     tracker = Piwik.addTracker(trackerUrl, matomoConfig.idSite);
                     configuredTrackers[variableName] = tracker;
 
@@ -171,12 +178,16 @@
         };
 
         var matomoConfig = parameters.get('matomoConfig', {});
+        if (matomoConfig.bundleTracker) {
+            loadMatomo();
+            // we don't return in case for some reason matomo was not loaded there, then we have the fallback
+        }
+
         if (!matomoConfig.matomoUrl || !matomoConfig.idSite) {
             return;
         }
 
         var matomoUrl = getMatomoUrlFromConfig(matomoConfig);
-
         loadTracker(matomoUrl);
     };
 })();

--- a/Template/Variable/MatomoConfigurationVariable.php
+++ b/Template/Variable/MatomoConfigurationVariable.php
@@ -146,7 +146,11 @@ class MatomoConfigurationVariable extends BaseVariable
                 $field->uiControlAttributes['field1'] = $field1->toArray();
                 $field->uiControlAttributes['field2'] = $field2->toArray();
             }),
-
+            $this->makeSetting('bundleTracker', true, FieldConfig::TYPE_BOOL, function (FieldConfig $field) {
+                $field->title = 'Bundle Tracker';
+                $field->uiControl = FieldConfig::UI_CONTROL_CHECKBOX;
+                $field->description = 'By bundling the Matomo JavaScript tracker directly into the container it may improve the performance of your website as it reduces the number of needed requests. It is recommended to bundle the Matomo tracker because in most cases the tracker would otherwise be otherwise loaded in a separate request on page view anyway. Note: If you use two different Matomo configurations in one container, the setting of the first configuration used in the first Matomo Tag will be applied to all Matomo tags within one container.';
+            }),
         );
     }
 

--- a/tests/Integration/Template/Tag/MatomoTagTest.php
+++ b/tests/Integration/Template/Tag/MatomoTagTest.php
@@ -1,0 +1,131 @@
+<?php
+/**
+ * Matomo - free/libre analytics platform
+ *
+ * @link https://matomo.org
+ * @license http://www.gnu.org/licenses/gpl-3.0.html GPL v3 or later
+ */
+
+namespace Piwik\Plugins\TagManager\tests\Integration\Template\Tag;
+
+use Piwik\API\Request;
+use Piwik\Container\StaticContainer;
+use Piwik\Plugins\TagManager\Context\WebContext;
+use Piwik\Plugins\TagManager\TagManager;
+use Piwik\Plugins\TagManager\Template\Tag\MatomoTag;
+use Piwik\Plugins\TagManager\Template\Trigger\PageViewTrigger;
+use Piwik\Plugins\TagManager\Template\Variable\MatomoConfigurationVariable;
+use Piwik\Plugins\TagManager\tests\Framework\TestCase\IntegrationTestCase;
+use Piwik\Tests\Framework\Fixture;
+
+/**
+ * @group TagManager
+ * @group MatomoTag
+ * @group MatomoTagTest
+ * @group Plugins
+ */
+class MatomoTagTest extends IntegrationTestCase
+{
+    private $idSite;
+
+    public function setUp()
+    {
+        parent::setUp();
+
+        TagManager::$enableAutoContainerCreation = false;
+        $this->idSite = Fixture::createWebsite('2014-01-02 03:04:05');
+    }
+
+    public function test_loadTemplate_getUnbundled()
+    {
+        $template = $this->createTag(false);
+        $this->checkMatomoTagIsLoaded($template);
+
+        // we must ensure this line exists as it will be replaced with tracker when bundled
+        $this->assertContains(MatomoTag::REPLACE_TRACKER_KEY, $template);
+    }
+
+    public function test_loadTemplate_getBundled()
+    {
+        $template = $this->createTag(true);
+
+        $this->checkMatomoTagIsLoaded($template);
+
+        // should have been replaced with Matomo code
+        $this->assertNotContains(MatomoTag::REPLACE_TRACKER_KEY, $template);
+        // simple test to check tracker is included
+        $this->assertContains('loadMatomo', $template);
+        $this->assertContains('this.trackPageView=function(', $template);
+        $this->assertContains('findContentNodesWithinNode', $template);
+    }
+
+    private function checkMatomoTagIsLoaded($template)
+    {
+        $this->assertContains('MatomoTag', $template);
+        $this->assertContains('loadMatomo', $template);
+    }
+
+    private function createTag($bundled)
+    {
+        $idContainer = Request::processRequest('TagManager.addContainer', array(
+            'idSite' => $this->idSite,
+            'name' => 'Foo', 'context' => WebContext::ID
+        ));
+        $container = Request::processRequest('TagManager.getContainer', array(
+            'idSite' => $this->idSite,
+            'idContainer' => $idContainer
+        ));
+        $draftVersion = $container['draft']['idcontainerversion'];
+        $idTrigger = Request::processRequest('TagManager.addContainerTrigger', array(
+            'idSite' => $this->idSite,
+            'idContainer' => $idContainer,
+            'idContainerVersion' => $draftVersion,
+            'type' => PageViewTrigger::ID,
+            'name' => 'MyTrigger'
+        ));
+
+        $variableName = 'MyConfig';
+        $idVariable = Request::processRequest('TagManager.addContainerVariable', array(
+            'idSite' => $this->idSite,
+            'idContainer' => $idContainer,
+            'idContainerVersion' => $draftVersion,
+            'type' => MatomoConfigurationVariable::ID,
+            'name' => $variableName,
+            'parameters' => array(
+                'bundleTracker' => (int) $bundled
+            )
+        ));
+
+        Request::processRequest('TagManager.addContainerTag', array(
+            'idSite' => $this->idSite,
+            'idContainer' => $idContainer,
+            'idContainerVersion' => $draftVersion,
+            'type' => MatomoTag::ID,
+            'name' => 'myTag',
+            'fireTriggerIds' => array($idTrigger),
+            'parameters' => array(
+                MatomoTag::PARAM_MATOMO_CONFIG => '{{'.$variableName.'}}'
+            )
+        ));
+        Request::processRequest('TagManager.enablePreviewMode', array(
+            'idSite' => $this->idSite,
+            'idContainer' => $idContainer
+        ));
+
+        $container = Request::processRequest('TagManager.getContainer', array(
+            'idSite' => $this->idSite,
+            'idContainer' => $idContainer
+        ));
+
+        $context = StaticContainer::get('Piwik\Plugins\TagManager\Context\WebContext');
+        $content = $context->generate($container);
+
+        foreach ($content as $file => $template) {
+            // all other generated files would not contain the Matomo tag because no version was created
+            if (strpos($file, 'preview') > 0) {
+                return $template;
+            }
+        }
+    }
+
+}

--- a/tests/System/expected/test___TagManager.exportContainerVersion_site_default_container.xml
+++ b/tests/System/expected/test___TagManager.exportContainerVersion_site_default_container.xml
@@ -85,6 +85,7 @@
 				<userId />
 				<customDimensions>
 				</customDimensions>
+				<bundleTracker>1</bundleTracker>
 			</parameters>
 			<lookup_table>
 			</lookup_table>

--- a/tests/System/expected/test_webContext__TagManager.getAvailableVariableTypesInContext.xml
+++ b/tests/System/expected/test_webContext__TagManager.getAvailableVariableTypesInContext.xml
@@ -738,6 +738,22 @@
 						<introduction />
 						<condition />
 					</row>
+					<row>
+						<name>bundleTracker</name>
+						<title>Bundle Tracker</title>
+						<value>1</value>
+						<defaultValue>1</defaultValue>
+						<type>boolean</type>
+						<uiControl>checkbox</uiControl>
+						<uiControlAttributes>
+						</uiControlAttributes>
+						<availableValues />
+						<description>By bundling the Matomo JavaScript tracker directly into the container it may improve the performance of your website as it reduces the number of needed requests. It is recommended to bundle the Matomo tracker because in most cases the tracker would otherwise be otherwise loaded in a separate request on page view anyway. Note: If you use two different Matomo configurations in one container, the setting of the first configuration used in the first Matomo Tag will be applied to all Matomo tags within one container.</description>
+						<inlineHelp />
+						<templateFile />
+						<introduction />
+						<condition />
+					</row>
 				</parameters>
 			</row>
 		</types>


### PR DESCRIPTION
This way the Matomo tracker will be loaded faster, and reduces the load on the server as only one file needs to be served on each request instead of two.

fix https://github.com/matomo-org/tag-manager/issues/2