### PR TITLE
Make sure that if JS tracker doesnt get bundled the tracking still works

### DIFF
--- a/Template/Tag/MatomoTag.php
+++ b/Template/Tag/MatomoTag.php
@@ -115,9 +115,19 @@ class MatomoTag extends BaseTag
     public function loadTemplate($context, $entity)
     {
         $template = parent::loadTemplate($context, $entity);
-        if ($template && !empty($entity['parameters']['matomoConfig']['parameters']['bundleTracker'])) {
+        // !isset() because when bundleTracker is not defined for some reason we enable it by default
+        $bundleTrackerEnabled = !isset($entity['parameters']['matomoConfig']['parameters']['bundleTracker'])
+                             || !empty($entity['parameters']['matomoConfig']['parameters']['bundleTracker']);
+        if ($template && $bundleTrackerEnabled) {
             $trackerUpdater = StaticContainer::get('Piwik\Plugins\CustomPiwikJs\TrackerUpdater');
             $tracker = $trackerUpdater->getUpdatedTrackerFileContent();
+
+            if (!$tracker) {
+                $tracker = @file_get_contents(PIWIK_DOCUMENT_ROOT . '/matomo.js');
+            } elseif (!$tracker) {
+                $tracker = @file_get_contents(PIWIK_DOCUMENT_ROOT . '/piwik.js');
+            }
+
             return str_replace(self::REPLACE_TRACKER_KEY, $tracker, $template);
         }
         return $template;

--- a/Template/Tag/MatomoTag.web.js
+++ b/Template/Tag/MatomoTag.web.js
@@ -43,8 +43,8 @@
             return;
         }
         var replaceMeWithTracker=''; // do not modify this line, be replaced with Matomo tracker. Cannot use /*!! comment because of Jshrink bug
-        libAvailable = true;
-        libLoaded = true;
+        libAvailable = typeof window.Piwik !== 'undefined' || typeof window.Matomo !== 'undefined';
+        libLoaded = libAvailable;
     }
 
     function loadTracker(url)


### PR DESCRIPTION
We've seen a container where for some reason the tracker was supposed to be bundled, but wasn't. I cannot reproduce it, but think this should fix the issue.