### PR TITLE
Improve TagManager plugin activation behaviour

### DIFF
--- a/TagManager.php
+++ b/TagManager.php
@@ -28,6 +28,7 @@ use Piwik\Plugins\TagManager\Dao\TagsDao;
 use Piwik\Plugins\TagManager\Dao\TriggersDao;
 use Piwik\Plugins\TagManager\Dao\VariablesDao;
 use Piwik\Plugins\CoreHome\SystemSummary;
+use Piwik\Plugins\TagManager\Model\Container\ContainerIdGenerator;
 use Piwik\Plugins\TagManager\Model\Salt;
 use Piwik\Site;
 use Piwik\View;
@@ -210,6 +211,20 @@ class TagManager extends \Piwik\Plugin
     {
         $pluginManager = Plugin\Manager::getInstance();
         if (!$pluginManager->isPluginInstalled('TagManager')) {
+            return;
+        }
+
+        try {
+            StaticContainer::get(ContainerIdGenerator::class);
+        } catch (\Exception $e){
+            // tag manager was likely activated in this request because the DI config could not be resolved.
+            // this happens eg when calling "plugin:activate TagManager AnotherPluginName".
+            // in this case tag manager gets installed and activated, and then during the same request, when
+            // AnotherPluginName is being installed, it will go into this method because we listen to plugin
+            // change events and component change events. It will then try to get the container but it fails
+            // because at the beginning of the request, the TagManager was not yet activated and therefore the
+            // TagManager/config/config.php was not loaded. In this case we skip generating containers as it would fail
+            // and a container would not yet exist anyway.
             return;
         }
 


### PR DESCRIPTION
See the comment

 // tag manager was likely activated in this request because the DI config could not be resolved.
            // this happens eg when calling "plugin:activate TagManager AnotherPluginName".
            // in this case tag manager gets installed and activated, and then during the same request, when
            // AnotherPluginName is being installed, it will go into this method because we listen to plugin
            // change events and component change events. It will then try to get the container but it fails
            // because at the beginning of the request, the TagManager was not yet activated and therefore the
            // TagManager/config/config.php was not loaded. In this case we skip generating containers as it would fail
            // and a container would not yet exist anyway.