### PR TITLE
Trigger activity only if that api was called directly

### DIFF
--- a/Activity/BaseActivity.php
+++ b/Activity/BaseActivity.php
@@ -7,6 +7,8 @@
  */
 namespace Piwik\Plugins\TagManager\Activity;
 
+use Piwik\API\Request;
+use Piwik\Cache;
 use Piwik\Container\StaticContainer;
 use Piwik\Piwik;
 use Piwik\Plugins\ActivityLog\Activity\Activity;
@@ -15,6 +17,15 @@ use Piwik\Site;
 abstract class BaseActivity extends Activity
 {
     protected $entityType = '';
+
+    protected function hasRequestedApiMethod($method)
+    {
+        if (method_exists('Piwik\API\Request', 'getRootApiRequestMethod')) {
+            $method = 'TagManager.' . $method;
+            return $method === Request::getRootApiRequestMethod();
+        }
+        return false;
+    }
 
     protected function getContainerNameFromActivityData($activityData)
     {

--- a/Activity/TagAdded.php
+++ b/Activity/TagAdded.php
@@ -14,6 +14,10 @@ class TagAdded extends TagBaseActivity
 
     public function extractParams($eventData)
     {
+        if (!$this->hasRequestedApiMethod('addContainerTag')) {
+            return false;
+        }
+
         list($idEntity, $finalAPIParameters) = $eventData;
 
         $idSite = $finalAPIParameters['parameters']['idSite'];

--- a/Activity/TagDeleted.php
+++ b/Activity/TagDeleted.php
@@ -14,6 +14,10 @@ class TagDeleted extends TagBaseActivity
 
     public function extractParams($eventData)
     {
+        if (!$this->hasRequestedApiMethod('deleteContainerTag')) {
+            return false;
+        }
+
         if (empty($eventData[0]) || !is_array($eventData[0])) {
             return false;
         }

--- a/Activity/TagUpdated.php
+++ b/Activity/TagUpdated.php
@@ -14,6 +14,10 @@ class TagUpdated extends TagBaseActivity
 
     public function extractParams($eventData)
     {
+        if (!$this->hasRequestedApiMethod('updateContainerTag')) {
+            return false;
+        }
+
         list($return, $finalAPIParameters) = $eventData;
 
         $idEntity = $finalAPIParameters['parameters']['idTag'];

--- a/Activity/TriggerAdded.php
+++ b/Activity/TriggerAdded.php
@@ -14,6 +14,10 @@ class TriggerAdded extends TriggerBaseActivity
 
     public function extractParams($eventData)
     {
+        if (!$this->hasRequestedApiMethod('addContainerTrigger')) {
+            return false;
+        }
+
         list($idEntity, $finalAPIParameters) = $eventData;
 
         $idSite = $finalAPIParameters['parameters']['idSite'];

--- a/Activity/TriggerDeleted.php
+++ b/Activity/TriggerDeleted.php
@@ -14,6 +14,10 @@ class TriggerDeleted extends TriggerBaseActivity
 
     public function extractParams($eventData)
     {
+        if (!$this->hasRequestedApiMethod('deleteContainerTrigger')) {
+            return false;
+        }
+
         if (empty($eventData[0]) || !is_array($eventData[0])) {
             return false;
         }

--- a/Activity/TriggerUpdated.php
+++ b/Activity/TriggerUpdated.php
@@ -14,6 +14,9 @@ class TriggerUpdated extends TriggerBaseActivity
 
     public function extractParams($eventData)
     {
+        if (!$this->hasRequestedApiMethod('updateContainerTrigger')) {
+            return false;
+        }
         list($return, $finalAPIParameters) = $eventData;
 
         $idEntity = $finalAPIParameters['parameters']['idTrigger'];

--- a/Activity/VariableAdded.php
+++ b/Activity/VariableAdded.php
@@ -14,6 +14,9 @@ class VariableAdded extends VariableBaseActivity
 
     public function extractParams($eventData)
     {
+        if (!$this->hasRequestedApiMethod('addContainerVariable')) {
+            return false;
+        }
         list($idEntity, $finalAPIParameters) = $eventData;
 
         $idSite = $finalAPIParameters['parameters']['idSite'];

--- a/Activity/VariableDeleted.php
+++ b/Activity/VariableDeleted.php
@@ -14,6 +14,9 @@ class VariableDeleted extends VariableBaseActivity
 
     public function extractParams($eventData)
     {
+        if (!$this->hasRequestedApiMethod('deleteContainerVariable')) {
+            return false;
+        }
         if (empty($eventData[0]) || !is_array($eventData[0])) {
             return false;
         }

--- a/Activity/VariableUpdated.php
+++ b/Activity/VariableUpdated.php
@@ -14,6 +14,9 @@ class VariableUpdated extends VariableBaseActivity
 
     public function extractParams($eventData)
     {
+        if (!$this->hasRequestedApiMethod('updateContainerVariable')) {
+            return false;
+        }
         list($return, $finalAPIParameters) = $eventData;
 
         $idEntity = $finalAPIParameters['parameters']['idVariable'];


### PR DESCRIPTION
Otherwise, when publishing for example a container, it will create lots of Add tags, triggers, variables activities.