### PR TITLE
The tag manager debug screen should not require 2FA

### DIFF
--- a/TagManager.php
+++ b/TagManager.php
@@ -62,10 +62,18 @@ class TagManager extends \Piwik\Plugin
             'Tracker.PageUrl.getQueryParametersToExclude' => 'getQueryParametersToExclude',
             'API.addGlossaryItems' => 'addGlossaryItems',
             'Template.bodyClass' => 'addBodyClass',
-            'Access.Capability.addCapabilities' => 'addCapabilities'
+            'Access.Capability.addCapabilities' => 'addCapabilities',
+            'TwoFactorAuth.requiresTwoFactorAuthentication' => 'requiresTwoFactorAuthentication'
         );
     }
-    
+
+    public function requiresTwoFactorAuthentication(&$requiresAuth, $module, $action, $parameters)
+    {
+        if ($module == 'TagManager' && $action === 'debug') {
+            $requiresAuth = false;
+        }
+    }
+
     public function addBodyClass(&$out, $type)
     {
         if ($type === 'tagmanager') {


### PR DESCRIPTION
Fixes if 2FA is forced for everyone, it would potentially render the 2FA setup or the 2FA code prompt instead of the debug frame.

We can safely ignore it here as it is called mainly by `doAsSuperUser` and it is a fixed script that is same for everyone with no variables or anything. (it could be basically as well available for anonymous). 