### PR TITLE
Load matomo tracker only when the tracker is fired

### DIFF
--- a/Template/Tag/MatomoTag.web.js
+++ b/Template/Tag/MatomoTag.web.js
@@ -198,19 +198,23 @@
                     }
                 }
             });
+
+            // we load the matomo tracker only when the tag was fired
+            // and we load it only after adding the callback, this way we make sure at least for the first matomo tag
+            // to initialize the tracker during window.piwikPluginAsyncInit
+
+            var matomoConfig = parameters.get('matomoConfig', {});
+            if (matomoConfig.bundleTracker) {
+                loadMatomo();
+                // we don't return in case for some reason matomo was not loaded there, then we have the fallback
+            }
+
+            if (!matomoConfig.matomoUrl || !matomoConfig.idSite) {
+                return;
+            }
+
+            var matomoUrl = getMatomoUrlFromConfig(matomoConfig);
+            loadTracker(matomoUrl);
         };
-
-        var matomoConfig = parameters.get('matomoConfig', {});
-        if (matomoConfig.bundleTracker) {
-            loadMatomo();
-            // we don't return in case for some reason matomo was not loaded there, then we have the fallback
-        }
-
-        if (!matomoConfig.matomoUrl || !matomoConfig.idSite) {
-            return;
-        }
-
-        var matomoUrl = getMatomoUrlFromConfig(matomoConfig);
-        loadTracker(matomoUrl);
     };
 })();

--- a/Template/Tag/MatomoTag.web.js
+++ b/Template/Tag/MatomoTag.web.js
@@ -126,6 +126,10 @@
                         tracker.setCookiePath(matomoConfig.cookiePath);
                     }
 
+                    if (matomoConfig.alwaysUseSendBeacon) {
+                        tracker.alwaysUseSendBeacon();
+                    }
+
                     if (matomoConfig.enableLinkTracking) {
                         tracker.enableLinkTracking();
                     }

--- a/Template/Variable/MatomoConfigurationVariable.php
+++ b/Template/Variable/MatomoConfigurationVariable.php
@@ -124,6 +124,10 @@ class MatomoConfigurationVariable extends BaseVariable
                 $field->description = 'When tracking many subdirectories in separate websites, the cookie path prevents the number of cookies to quickly increase and prevent browser from deleting some of the cookies. This ensures optimal data accuracy and improves performance for your users (fewer cookies are sent with each request).';
                 $field->validators[] = new CharacterLength(0, 500);
             }),
+            $this->makeSetting('alwaysUseSendBeacon', false, FieldConfig::TYPE_BOOL, function (FieldConfig $field) {
+                $field->title = 'Always use sendBeacon';
+                $field->description = 'Enables send beacon usage instead of a regular ajax request. This means when a user clicks for example on an outlink, the navigation to this page will happen much faster.';
+            }),
             $this->makeSetting('userId', '', FieldConfig::TYPE_STRING, function (FieldConfig $field) {
                 $field->title = 'User ID';
                 $field->description = 'Sets a User ID to this user (such as an email address or a username).';

--- a/tests/System/expected/test___TagManager.exportContainerVersion_site_default_container.xml
+++ b/tests/System/expected/test___TagManager.exportContainerVersion_site_default_container.xml
@@ -85,6 +85,7 @@
 				<setSecureCookie>0</setSecureCookie>
 				<cookieDomain />
 				<cookiePath />
+				<alwaysUseSendBeacon>0</alwaysUseSendBeacon>
 				<userId />
 				<customDimensions>
 				</customDimensions>

--- a/tests/System/expected/test_webContext__TagManager.getAvailableVariableTypesInContext.xml
+++ b/tests/System/expected/test_webContext__TagManager.getAvailableVariableTypesInContext.xml
@@ -915,6 +915,22 @@
 						<condition />
 					</row>
 					<row>
+						<name>alwaysUseSendBeacon</name>
+						<title>Always use sendBeacon</title>
+						<value>0</value>
+						<defaultValue>0</defaultValue>
+						<type>boolean</type>
+						<uiControl>checkbox</uiControl>
+						<uiControlAttributes>
+						</uiControlAttributes>
+						<availableValues />
+						<description>Enables send beacon usage instead of a regular ajax request. This means when a user clicks for example on an outlink, the navigation to this page will happen much faster.</description>
+						<inlineHelp />
+						<templateFile />
+						<introduction />
+						<condition />
+					</row>
+					<row>
 						<name>userId</name>
 						<title>User ID</title>
 						<value />


### PR DESCRIPTION
This PR brings couple improvements

* Before if someone used a Matomo Tag in the container, the Matomo tracking code was always loaded no matter if the tag was fired or not
* Now at least the first tracker will be initialized as part of `window.piwikPluginAsyncInit` as recommended fixing some compatibility issues with custom Matomo tracker plugins at least for the first Matomo tag (when not bundled may also fix it for other matomo tags depending how long it takes to load the tracker file)
* Support send beacon