### PR TITLE
Fix JS Function Variable needs to generate one template per variable

### DIFF
--- a/Context/BaseContext/TemplateLocator.php
+++ b/Context/BaseContext/TemplateLocator.php
@@ -85,7 +85,7 @@ class TemplateLocator
             if ($template) {
                 $methodName = $variableType . 'Variable';
                 if ($variableType === CustomJsFunctionVariable::ID) {
-                    $methodName .= md5(json_encode($variable['parameters']));
+                    $methodName .= substr(md5(json_encode($variable['parameters'])), 0, 8);
                 }
                 $this->templateFunctions[$methodName] = $template;
 

--- a/Context/BaseContext/TemplateLocator.php
+++ b/Context/BaseContext/TemplateLocator.php
@@ -9,6 +9,7 @@ namespace Piwik\Plugins\TagManager\Context\BaseContext;
 
 use Piwik\Plugins\TagManager\Template\Tag\TagsProvider;
 use Piwik\Plugins\TagManager\Template\Trigger\TriggersProvider;
+use Piwik\Plugins\TagManager\Template\Variable\CustomJsFunctionVariable;
 use Piwik\Plugins\TagManager\Template\Variable\VariablesProvider;
 
 class TemplateLocator
@@ -82,7 +83,10 @@ class TemplateLocator
         if ($variableTemplate) {
             $template = $variableTemplate->loadTemplate($contextId, $variable);
             if ($template) {
-                $methodName = $variable['type'] . 'Variable';
+                $methodName = $variableType . 'Variable';
+                if ($variableType === CustomJsFunctionVariable::ID) {
+                    $methodName .= md5(json_encode($variable['parameters']));
+                }
                 $this->templateFunctions[$methodName] = $template;
 
                 return $methodName;

--- a/tests/Integration/Context/BaseContext/TemplateLocatorTest.php
+++ b/tests/Integration/Context/BaseContext/TemplateLocatorTest.php
@@ -13,6 +13,7 @@ use Piwik\Plugins\TagManager\Context\BaseContext\TemplateLocator;
 use Piwik\Plugins\TagManager\Context\WebContext;
 use Piwik\Plugins\TagManager\Template\Tag\CustomHtmlTag;
 use Piwik\Plugins\TagManager\Template\Trigger\CustomEventTrigger;
+use Piwik\Plugins\TagManager\Template\Variable\CustomJsFunctionVariable;
 use Piwik\Plugins\TagManager\Template\Variable\DataLayerVariable;
 use Piwik\Plugins\TagManager\tests\Framework\TestCase\IntegrationTestCase;
 
@@ -64,6 +65,26 @@ class TemplateLocatorTest extends IntegrationTestCase
         $templates = $this->templateLocator->getLoadedTemplates();
         $this->assertEquals(array('DataLayerVariable'), array_keys($templates));
         $this->assertContains("parameters.get('dataLayerName')", $templates['DataLayerVariable']);
+    }
+
+    public function test_loadVariableTemplate_GeneratesDifferentTemplatePerJsFunction()
+    {
+        foreach (array(2,1) as $id) {
+            // making sure the returned method name is based on jsFunction/parameters and not based on random value so for same function
+            // should return same method name
+            $result = $this->templateLocator->loadVariableTemplate(array('type' => CustomJsFunctionVariable::ID, 'id' => $id, 'parameters' => array('jsFunction' => 'function (){ return 1; }')), WebContext::ID);
+            $this->assertEquals('CustomJsFunctionVariableddb61d12', $result);
+
+            $templates = $this->templateLocator->getLoadedTemplates();
+            $this->assertEquals(array('CustomJsFunctionVariableddb61d12'), array_keys($templates));
+        }
+
+
+        $result = $this->templateLocator->loadVariableTemplate(array('type' => CustomJsFunctionVariable::ID, 'parameters' => array('jsFunction' => 'function (){ return 2; }')), WebContext::ID);
+        $this->assertEquals('CustomJsFunctionVariable786282aa', $result);
+
+        $templates = $this->templateLocator->getLoadedTemplates();
+        $this->assertEquals(array('CustomJsFunctionVariableddb61d12','CustomJsFunctionVariable786282aa'), array_keys($templates));
     }
 
     public function test_getLoadedTemplates_isEmptyByDefault()


### PR DESCRIPTION
refs https://github.com/matomo-org/tag-manager/issues/148

Not the best fix but only thing I can think of without needing to use `eval`