### PR TITLE
Add random id to preview url to avoid browser cache

### DIFF
--- a/javascripts/previewmodedetection.js
+++ b/javascripts/previewmodedetection.js
@@ -1,6 +1,6 @@
 if ((document.cookie.indexOf('$cookieId') !== -1 && window.location.search.indexOf('&$urlParamDisableId') === -1 && window.location.search.indexOf('?$urlParamDisableId') === -1) || window.location.search.indexOf('&$urlParamEnabledId') !== -1 || window.location.search.indexOf('?$urlParamEnabledId') !== -1) {
-
+    var rand = Math.floor(Math.random() * 999999998) + 1;
     var d=document, g=d.createElement('script'), s=d.getElementsByTagName('script')[0];
-    g.type='text/javascript'; g.async=false; g.defer=false; g.src='$previewUrl'; s.parentNode.insertBefore(g,s);
+    g.type='text/javascript'; g.async=false; g.defer=false; g.src='$previewUrl?rand=' + rand; s.parentNode.insertBefore(g,s);
     return;
 }

--- a/tests/System/expected/context_webcontext_generate.text
+++ b/tests/System/expected/context_webcontext_generate.text
@@ -1,8 +1,8 @@
 array (
   '/js/container_aaacont1.js' => '        if ((document.cookie.indexOf(\'mtmPreview2_aaacont1%3D1\') !== -1 && window.location.search.indexOf(\'&mtmPreviewMode=0\') === -1 && window.location.search.indexOf(\'?mtmPreviewMode=0\') === -1) || window.location.search.indexOf(\'&mtmPreviewMode=aaacont1\') !== -1 || window.location.search.indexOf(\'?mtmPreviewMode=aaacont1\') !== -1) {
-
+    var rand = Math.floor(Math.random() * 999999998) + 1;
     var d=document, g=d.createElement(\'script\'), s=d.getElementsByTagName(\'script\')[0];
-    g.type=\'text/javascript\'; g.async=false; g.defer=false; g.src=\'http://localhost/tests/PHPUnit/proxy/js/container_aaacont1_preview.js\'; s.parentNode.insertBefore(g,s);
+    g.type=\'text/javascript\'; g.async=false; g.defer=false; g.src=\'http://apache.piwik/tests/PHPUnit/proxy/js/container_aaacont1_preview.js?rand=\' + rand; s.parentNode.insertBefore(g,s);
     return;
 }
         var content = \'foobar\';
@@ -45,9 +45,9 @@ Templates[\'ErrorUrlVariable\'] = function () { var x = 1; }
 Templates[\'DomReadyTrigger\'] = function () { var x = 1; } 
 window.MatomoTagManager.addContainer({"id":"aaacont1","idsite":2,"versionName":"container1_v4_reversioned","revision":4,"environment":"live","tags":[{"id":10,"type":"CustomHtml","name":"8345e7bb96d4218e2d16226c4270d278","parameters":{"customHtml":"<script><\\/script>","htmlPosition":"bodyEnd"},"blockTriggerIds":[14],"fireTriggerIds":[13],"fireLimit":"once_lifetime","fireDelay":1350,"startDate":"2017-01-02 03:04:05","endDate":"2029-01-02 03:04:05","Tag":"CustomHtmlTag"},{"id":11,"type":"CustomHtml","name":"d5b8a62874c0dbff8e0a987ee5415d4c","parameters":{"customHtml":"<p><\\/p>","htmlPosition":"bodyEnd"},"blockTriggerIds":[],"fireTriggerIds":[13],"fireLimit":"unlimited","fireDelay":0,"startDate":null,"endDate":null,"Tag":"CustomHtmlTag"},{"id":12,"type":"CustomImage","name":"de507228cec67c55088edf4928cf9db6","parameters":{"customImageSrc":"\\/plugins\\/tracking.png","cacheBusterEnabled":true},"blockTriggerIds":[],"fireTriggerIds":[14,15],"fireLimit":"unlimited","fireDelay":0,"startDate":null,"endDate":null,"Tag":"CustomImageTag"}],"triggers":[{"id":13,"type":"CustomEvent","name":"CustomEvent","parameters":{"eventName":"foo"},"conditions":[],"Trigger":"CustomEventTrigger"},{"id":14,"type":"WindowLoaded","name":"WindowLoaded","parameters":[],"conditions":[{"actual":{"name":"ErrorUrl","type":"ErrorUrl","lookUpTable":[],"defaultValue":null,"parameters":[],"Variable":"ErrorUrlVariable"},"comparison":"contains","expected":"foo"}],"Trigger":"WindowLoadedTrigger"},{"id":15,"type":"DomReady","name":"DomReady","parameters":[],"conditions":[],"Trigger":"DomReadyTrigger"}],"variables":[{"name":"ErrorUrl","type":"ErrorUrl","lookUpTable":[],"defaultValue":null,"parameters":[],"Variable":"ErrorUrlVariable"}]}, Templates);})()        ',
   '/js/container_aaacont1_dev_5145ce110dfb83505890f752.js' => '        if ((document.cookie.indexOf(\'mtmPreview2_aaacont1%3D1\') !== -1 && window.location.search.indexOf(\'&mtmPreviewMode=0\') === -1 && window.location.search.indexOf(\'?mtmPreviewMode=0\') === -1) || window.location.search.indexOf(\'&mtmPreviewMode=aaacont1\') !== -1 || window.location.search.indexOf(\'?mtmPreviewMode=aaacont1\') !== -1) {
-
+    var rand = Math.floor(Math.random() * 999999998) + 1;
     var d=document, g=d.createElement(\'script\'), s=d.getElementsByTagName(\'script\')[0];
-    g.type=\'text/javascript\'; g.async=false; g.defer=false; g.src=\'http://localhost/tests/PHPUnit/proxy/js/container_aaacont1_preview.js\'; s.parentNode.insertBefore(g,s);
+    g.type=\'text/javascript\'; g.async=false; g.defer=false; g.src=\'http://apache.piwik/tests/PHPUnit/proxy/js/container_aaacont1_preview.js?rand=\' + rand; s.parentNode.insertBefore(g,s);
     return;
 }
         var content = \'foobar\';
@@ -90,9 +90,9 @@ Templates[\'ErrorUrlVariable\'] = function () { var x = 1; }
 Templates[\'DomReadyTrigger\'] = function () { var x = 1; } 
 window.MatomoTagManager.addContainer({"id":"aaacont1","idsite":2,"versionName":"container1_v4_reversioned","revision":4,"environment":"dev","tags":[{"id":10,"type":"CustomHtml","name":"8345e7bb96d4218e2d16226c4270d278","parameters":{"customHtml":"<script><\\/script>","htmlPosition":"bodyEnd"},"blockTriggerIds":[14],"fireTriggerIds":[13],"fireLimit":"once_lifetime","fireDelay":1350,"startDate":"2017-01-02 03:04:05","endDate":"2029-01-02 03:04:05","Tag":"CustomHtmlTag"},{"id":11,"type":"CustomHtml","name":"d5b8a62874c0dbff8e0a987ee5415d4c","parameters":{"customHtml":"<p><\\/p>","htmlPosition":"bodyEnd"},"blockTriggerIds":[],"fireTriggerIds":[13],"fireLimit":"unlimited","fireDelay":0,"startDate":null,"endDate":null,"Tag":"CustomHtmlTag"},{"id":12,"type":"CustomImage","name":"de507228cec67c55088edf4928cf9db6","parameters":{"customImageSrc":"\\/plugins\\/tracking.png","cacheBusterEnabled":true},"blockTriggerIds":[],"fireTriggerIds":[14,15],"fireLimit":"unlimited","fireDelay":0,"startDate":null,"endDate":null,"Tag":"CustomImageTag"}],"triggers":[{"id":13,"type":"CustomEvent","name":"CustomEvent","parameters":{"eventName":"foo"},"conditions":[],"Trigger":"CustomEventTrigger"},{"id":14,"type":"WindowLoaded","name":"WindowLoaded","parameters":[],"conditions":[{"actual":{"name":"ErrorUrl","type":"ErrorUrl","lookUpTable":[],"defaultValue":null,"parameters":[],"Variable":"ErrorUrlVariable"},"comparison":"contains","expected":"foo"}],"Trigger":"WindowLoadedTrigger"},{"id":15,"type":"DomReady","name":"DomReady","parameters":[],"conditions":[],"Trigger":"DomReadyTrigger"}],"variables":[{"name":"ErrorUrl","type":"ErrorUrl","lookUpTable":[],"defaultValue":null,"parameters":[],"Variable":"ErrorUrlVariable"}]}, Templates);})()        ',
   '/js/container_aaacont1_staging_a7295f29fb160dcfb59d3193.js' => '        if ((document.cookie.indexOf(\'mtmPreview2_aaacont1%3D1\') !== -1 && window.location.search.indexOf(\'&mtmPreviewMode=0\') === -1 && window.location.search.indexOf(\'?mtmPreviewMode=0\') === -1) || window.location.search.indexOf(\'&mtmPreviewMode=aaacont1\') !== -1 || window.location.search.indexOf(\'?mtmPreviewMode=aaacont1\') !== -1) {
-
+    var rand = Math.floor(Math.random() * 999999998) + 1;
     var d=document, g=d.createElement(\'script\'), s=d.getElementsByTagName(\'script\')[0];
-    g.type=\'text/javascript\'; g.async=false; g.defer=false; g.src=\'http://localhost/tests/PHPUnit/proxy/js/container_aaacont1_preview.js\'; s.parentNode.insertBefore(g,s);
+    g.type=\'text/javascript\'; g.async=false; g.defer=false; g.src=\'http://apache.piwik/tests/PHPUnit/proxy/js/container_aaacont1_preview.js?rand=\' + rand; s.parentNode.insertBefore(g,s);
     return;
 }
         var content = \'foobar\';

--- a/tests/System/expected/context_webcontext_generate.text
+++ b/tests/System/expected/context_webcontext_generate.text
@@ -2,7 +2,7 @@ array (
   '/js/container_aaacont1.js' => '        if ((document.cookie.indexOf(\'mtmPreview2_aaacont1%3D1\') !== -1 && window.location.search.indexOf(\'&mtmPreviewMode=0\') === -1 && window.location.search.indexOf(\'?mtmPreviewMode=0\') === -1) || window.location.search.indexOf(\'&mtmPreviewMode=aaacont1\') !== -1 || window.location.search.indexOf(\'?mtmPreviewMode=aaacont1\') !== -1) {
     var rand = Math.floor(Math.random() * 999999998) + 1;
     var d=document, g=d.createElement(\'script\'), s=d.getElementsByTagName(\'script\')[0];
-    g.type=\'text/javascript\'; g.async=false; g.defer=false; g.src=\'http://apache.piwik/tests/PHPUnit/proxy/js/container_aaacont1_preview.js?rand=\' + rand; s.parentNode.insertBefore(g,s);
+    g.type=\'text/javascript\'; g.async=false; g.defer=false; g.src=\'http://localhost/tests/PHPUnit/proxy/js/container_aaacont1_preview.js?rand=\' + rand; s.parentNode.insertBefore(g,s);
     return;
 }
         var content = \'foobar\';
@@ -47,7 +47,7 @@ window.MatomoTagManager.addContainer({"id":"aaacont1","idsite":2,"versionName":"
   '/js/container_aaacont1_dev_5145ce110dfb83505890f752.js' => '        if ((document.cookie.indexOf(\'mtmPreview2_aaacont1%3D1\') !== -1 && window.location.search.indexOf(\'&mtmPreviewMode=0\') === -1 && window.location.search.indexOf(\'?mtmPreviewMode=0\') === -1) || window.location.search.indexOf(\'&mtmPreviewMode=aaacont1\') !== -1 || window.location.search.indexOf(\'?mtmPreviewMode=aaacont1\') !== -1) {
     var rand = Math.floor(Math.random() * 999999998) + 1;
     var d=document, g=d.createElement(\'script\'), s=d.getElementsByTagName(\'script\')[0];
-    g.type=\'text/javascript\'; g.async=false; g.defer=false; g.src=\'http://apache.piwik/tests/PHPUnit/proxy/js/container_aaacont1_preview.js?rand=\' + rand; s.parentNode.insertBefore(g,s);
+    g.type=\'text/javascript\'; g.async=false; g.defer=false; g.src=\'http://localhost/tests/PHPUnit/proxy/js/container_aaacont1_preview.js?rand=\' + rand; s.parentNode.insertBefore(g,s);
     return;
 }
         var content = \'foobar\';
@@ -92,7 +92,7 @@ window.MatomoTagManager.addContainer({"id":"aaacont1","idsite":2,"versionName":"
   '/js/container_aaacont1_staging_a7295f29fb160dcfb59d3193.js' => '        if ((document.cookie.indexOf(\'mtmPreview2_aaacont1%3D1\') !== -1 && window.location.search.indexOf(\'&mtmPreviewMode=0\') === -1 && window.location.search.indexOf(\'?mtmPreviewMode=0\') === -1) || window.location.search.indexOf(\'&mtmPreviewMode=aaacont1\') !== -1 || window.location.search.indexOf(\'?mtmPreviewMode=aaacont1\') !== -1) {
     var rand = Math.floor(Math.random() * 999999998) + 1;
     var d=document, g=d.createElement(\'script\'), s=d.getElementsByTagName(\'script\')[0];
-    g.type=\'text/javascript\'; g.async=false; g.defer=false; g.src=\'http://apache.piwik/tests/PHPUnit/proxy/js/container_aaacont1_preview.js?rand=\' + rand; s.parentNode.insertBefore(g,s);
+    g.type=\'text/javascript\'; g.async=false; g.defer=false; g.src=\'http://localhost/tests/PHPUnit/proxy/js/container_aaacont1_preview.js?rand=\' + rand; s.parentNode.insertBefore(g,s);
     return;
 }
         var content = \'foobar\';


### PR DESCRIPTION
Avoids having to force reload with clearing browser cache if preview changes. Only problem may be debugging is that debugging in the browser might be harder. Could be interesting having an option not to append the parameter.