### PR TITLE
Automatically prefill version number if last version was integer

### DIFF
--- a/angularjs/manageVersion/edit.controller.js
+++ b/angularjs/manageVersion/edit.controller.js
@@ -106,6 +106,10 @@
                         self.versionChanges = diff;
                         self.isLoadingVersionChanges = false;
                     });
+
+                    if (self.create && !self.version.name && /^\d+$/.test(self.lastVersion)) {
+                        self.version.name = parseInt(self.lastVersion, 10) + 1;
+                    }
                 }
             });
 


### PR DESCRIPTION
As discussed, we keep it super simple and only suggest a version number if last version was an integer/number. We don't increase for now versions like `v5` or `5.4.1` (we wouldn't know if it's a minor/major/patch release etc)

fix #115