### PR TITLE
Matomo Tag: set the id site later so that cookies are created correctly

### DIFF
--- a/Template/Tag/MatomoTag.web.js
+++ b/Template/Tag/MatomoTag.web.js
@@ -126,6 +126,8 @@
                         tracker.setCookiePath(matomoConfig.cookiePath);
                     }
 
+                    tracker.setSiteId(matomoConfig.idSite);
+                    
                     if (matomoConfig.alwaysUseSendBeacon) {
                         tracker.alwaysUseSendBeacon();
                     }
@@ -148,8 +150,6 @@
                     if (matomoConfig.trackVisibleContentImpressions) {
                         tracker.trackVisibleContentImpressions();
                     }
-                    
-                    tracker.setSiteId(matomoConfig.idSite);
                 }
 
                 if ((matomoConfig.userId || tracker.getUserId()) && lastUserId !== matomoConfig.userId) {

--- a/Template/Tag/MatomoTag.web.js
+++ b/Template/Tag/MatomoTag.web.js
@@ -103,7 +103,7 @@
                     // but even two or more different configs for the same Matomo URL & idSite
                     lastMatomoUrl = getMatomoUrlFromConfig(matomoConfig);
                     var trackerUrl = lastMatomoUrl + 'piwik.php';
-                    tracker = Piwik.addTracker(trackerUrl, matomoConfig.idSite);
+                    tracker = Piwik.addTracker(trackerUrl);
                     configuredTrackers[variableName] = tracker;
 
                     if (matomoConfig.disableCookies) {
@@ -148,6 +148,8 @@
                     if (matomoConfig.trackVisibleContentImpressions) {
                         tracker.trackVisibleContentImpressions();
                     }
+                    
+                    tracker.setSiteId(matomoConfig.idSite);
                 }
 
                 if ((matomoConfig.userId || tracker.getUserId()) && lastUserId !== matomoConfig.userId) {


### PR DESCRIPTION
Steps to reproduce:
* Create a Matomo tag on a container, configured with cookie domain `.example.com`
* Load the website www.example.com
* Got: Two cookies are created on domains .example.com and www.example.com eg.
```
9b1feac345884afb.1553796770.0.1553796834.. on domaine www.example.com
97b1f55eea218e3e.1553796770.1.1553796834.1553796770. on .example.com
```
* Expected only one cookie on .example.com

Looked a bit into it and found that:
* in the container it calls `        tracker = Piwik.addTracker(trackerUrl, matomoConfig.idSite);`
* which then triggers the line `setVisitorIdCookie();` in the Tracker constructor
* which creates the wrong cookie on `www.example.com`
* the wrong cookie is created because at this point, the function `setCookieDomains` hasn't been called yet. It's called a bit later in: https://github.com/matomo-org/tag-manager/blob/0.2.6/Template/Tag/MatomoTag.web.js#L121-L123
* hence why in this PR by moving the setSiteId to after the `setCookie*` functions are called, I think may fix the issue

Note: it is un-tested