### PR TITLE
Check container version exists before publishing it

### DIFF
--- a/Model/Container.php
+++ b/Model/Container.php
@@ -350,6 +350,9 @@ class Container extends BaseModel
         $this->dao->updateContainerColumns($idSite, $idContainer, $columns);
     }
 
+    /**
+     * @return \Piwik\Plugins\TagManager\API\Export
+     */
     private function getExport()
     {
         return StaticContainer::get('Piwik\Plugins\TagManager\API\Export');

--- a/angularjs/manageVersion/edit.controller.js
+++ b/angularjs/manageVersion/edit.controller.js
@@ -221,12 +221,12 @@
 
             tagManagerVersionModel.createOrUpdateVersion(this.version, 'TagManager.createContainerVersion').then(function (response) {
 
-                var idContainerVersion = response.response.value;
-
-                if (!response || response.type === 'error' || !response.response) {
+                if (!response || response.type === 'error' || !response.response || !response.response.value) {
                     self.isUpdating = false;
                     return;
                 }
+
+                var idContainerVersion = response.response.value;
 
                 self.version.idcontainerversion = idContainerVersion;
 


### PR DESCRIPTION
refs https://forum.matomo.org/t/tag-manager-all-tags-deleted-during-version-creation/33548

I doubt it fixes anything though because if creating a new version failed, it would return an API error.