### PR TITLE
Prevent error "cannot read property 'firstChild' of null"

### DIFF
--- a/Template/Tag/CustomHtmlTag.web.js
+++ b/Template/Tag/CustomHtmlTag.web.js
@@ -236,8 +236,13 @@
 
                     if (htmlPosition === 'headStart' || htmlPosition === 'headEnd') {
                         moveNodes(parameters.document.head, children, append);
-                    } else {
+                    } else if (parameters.document.body) {
                         moveNodes(parameters.document.body, children, append);
+                    } else {
+                        // tag manager is embedded in head and loaded before body exists, need to wait for body to exist
+                        TagManager.dom.onReady(function () {
+                            moveNodes(parameters.document.body, children, append);
+                        });
                     }
                 }
             }


### PR DESCRIPTION
When Custom HTML tag is set to be inserted into the body, but the tag manager is embedded in the script header and loaded and executed before the body is present in the dom, we need to wait for the body to become available.