### PR TITLE
Adjustments for using TM and classic Tracking Code at the same time

### DIFF
--- a/Template/Tag/MatomoTag.web.js
+++ b/Template/Tag/MatomoTag.web.js
@@ -103,7 +103,11 @@
                     // but even two or more different configs for the same Matomo URL & idSite
                     lastMatomoUrl = getMatomoUrlFromConfig(matomoConfig);
                     var trackerUrl = lastMatomoUrl + matomoConfig.trackingEndpoint;
-                    tracker = Piwik.addTracker(trackerUrl);
+                    if (matomoConfig.registerAsDefaultTracker) {
+                        tracker = Piwik.addTracker(trackerUrl);
+                    } else {
+                        tracker = Piwik.getTracker(trackerUrl);
+                    }
                     configuredTrackers[variableName] = tracker;
 
                     if (matomoConfig.disableCookies) {

--- a/Template/Variable/MatomoConfigurationVariable.php
+++ b/Template/Variable/MatomoConfigurationVariable.php
@@ -211,6 +211,11 @@ class MatomoConfigurationVariable extends BaseVariable
                 $field->uiControl = FieldConfig::UI_CONTROL_CHECKBOX;
                 $field->description = 'By bundling the Matomo JavaScript tracker directly into the container it may improve the performance of your website as it reduces the number of needed requests. It is recommended to bundle the Matomo tracker because in most cases the tracker would otherwise be otherwise loaded in a separate request on page view anyway. Note: If you use two different Matomo configurations in one container, the setting of the first configuration used in the first Matomo Tag will be applied to all Matomo tags within one container.';
             }),
+            $this->makeSetting('registerAsDefaultTracker', true, FieldConfig::TYPE_BOOL, function (FieldConfig $field) {
+                $field->title = 'Register As Default Tracker';
+                $field->uiControl = FieldConfig::UI_CONTROL_CHECKBOX;
+                $field->description = 'When enabled, the tracker will be registered as the default one for the website, and will receive all commands that get pushed into the global _paq variable. Useful if you want to use the tracker config from the container with your own _paq.push() JavaScript code.';
+            }),
             $this->makeSetting('jsEndpoint', $jsEndpoint, FieldConfig::TYPE_STRING, function (FieldConfig $field) {
                 $field->title = 'Tracker Javascript Path';
                 $field->uiControl = FieldConfig::UI_CONTROL_SINGLE_SELECT;

--- a/tests/System/expected/test___TagManager.exportContainerVersion_site_default_container.xml
+++ b/tests/System/expected/test___TagManager.exportContainerVersion_site_default_container.xml
@@ -92,6 +92,7 @@
 				<customDimensions>
 				</customDimensions>
 				<bundleTracker>1</bundleTracker>
+				<registerAsDefaultTracker>1</registerAsDefaultTracker>
 				<jsEndpoint>matomo.js</jsEndpoint>
 				<trackingEndpoint>matomo.php</trackingEndpoint>
 			</parameters>

--- a/tests/System/expected/test_webContext__TagManager.getAvailableVariableTypesInContext.xml
+++ b/tests/System/expected/test_webContext__TagManager.getAvailableVariableTypesInContext.xml
@@ -1020,6 +1020,22 @@
 						<condition />
 					</row>
 					<row>
+						<name>registerAsDefaultTracker</name>
+						<title>Register As Default Tracker</title>
+						<value>1</value>
+						<defaultValue>1</defaultValue>
+						<type>boolean</type>
+						<uiControl>checkbox</uiControl>
+						<uiControlAttributes>
+						</uiControlAttributes>
+						<availableValues />
+						<description>When enabled, the tracker will be registered as the default one for the website, and will receive all commands that get pushed into the global _paq variable. Useful if you want to use the tracker config from the container with your own _paq.push() JavaScript code.</description>
+						<inlineHelp />
+						<templateFile />
+						<introduction />
+						<condition />
+					</row>
+					<row>
 						<name>jsEndpoint</name>
 						<title>Tracker Javascript Path</title>
 						<value>matomo.js</value>


### PR DESCRIPTION
* Added new setting "Use external Tracker" that allows to use a Matomo JS Tracker that is already loaded by the website by other means (for example the classic Matomo JS tracking code)
* Replaced Piwk.addTracker() with Piwik.getTracker(); this fixes using Matomo Tag Manager together with classic Matomo Code. addTracker() does some caching and did not work in my tests. getTracker() always creates a new Piwik instance, but since the Tag Manage code already caches the Piwik Instance this should be no problem