### PR TITLE
Do not regenerate containers after core archiving

### DIFF
--- a/TagManager.php
+++ b/TagManager.php
@@ -44,7 +44,6 @@ class TagManager extends \Piwik\Plugin
             'AssetManager.getJavaScriptFiles' => 'getJsFiles',
             'Translate.getClientSideTranslationKeys' => 'getClientSideTranslationKeys',
             'CoreUpdater.update.end' => 'regenerateReleasedContainers',
-            'CronArchive.end' => 'regenerateReleasedContainers',
             'PluginManager.pluginActivated' => 'onPluginActivateOrInstall',
             'PluginManager.pluginInstalled' => 'onPluginActivateOrInstall',
             'PluginManager.pluginDeactivated' => 'onPluginActivateOrInstall',


### PR DESCRIPTION
Not sure why I added it there considering they are being regenerated in a task every hour or so anyway.