### PR TITLE
feat: Created a config key to define custom containers and analytics url

### DIFF
--- a/Context/WebContext.php
+++ b/Context/WebContext.php
@@ -22,8 +22,7 @@ use Piwik\Plugins\TagManager\Model\Tag;
 use Piwik\Plugins\TagManager\Model\Trigger;
 use Piwik\Plugins\TagManager\Model\Variable;
 use Piwik\Plugins\TagManager\Template\Variable\VariablesProvider;
-use Piwik\SettingsPiwik;
-
+use Piwik\Plugins\TagManager\SystemSettings as Settings;
 
 class WebContext extends BaseContext
 {
@@ -212,7 +211,7 @@ class WebContext extends BaseContext
 
     private function getWebPathForRelease($idSite, $idContainer, $environment, $containerCreatedDate)
     {
-        $domain = SettingsPiwik::getPiwikUrl();
+        $domain = (new Settings())->getContainersUrl();
         if (Common::stringEndsWith($domain, '/')) {
             $domain = Common::mb_substr($domain, 0, -1);
         }

--- a/Template/Variable/MatomoConfigurationVariable.php
+++ b/Template/Variable/MatomoConfigurationVariable.php
@@ -9,11 +9,11 @@ namespace Piwik\Plugins\TagManager\Template\Variable;
 
 use Piwik\Common;
 use Piwik\Settings\FieldConfig;
-use Piwik\SettingsPiwik;
 use Piwik\Site;
 use Piwik\Validators\CharacterLength;
 use Piwik\Validators\NotEmpty;
 use Piwik\Validators\UrlLike;
+use Piwik\Plugins\TagManager\SystemSettings as Settings;
 
 class MatomoConfigurationVariable extends BaseVariable
 {
@@ -42,9 +42,10 @@ class MatomoConfigurationVariable extends BaseVariable
     public function getParameters()
     {
         $idSite = Common::getRequestVar('idSite', 0, 'int');
+        $settings = new Settings();
+        $url = $settings->getAnalyticsUrl();
 
-        $url = SettingsPiwik::getPiwikUrl();
-        if (SettingsPiwik::isHttpsForced()) {
+        if ($settings->isHttpsForced()) {
             $url = str_replace('http://', 'https://', $url);
         } else {
             $url = str_replace(array('http://', 'https://'), '//', $url);


### PR DESCRIPTION
This features wants to provide a way to custom the entrypoint to static
containers and analytics.
In a high traffic machine, analytics will use too much resource and it's
natural to use it behind a load balancer, but provide the static files on
the same serve may take a long time to response impacting on sites
performance.

Config Keys.
custom_containers_hostname
custom_analytics_hostname

Example:
custom_containers_hostname = cdn.example.com
custom_analytics_hostname = analytics.example.com
