### PR TITLE
Show embed code only if embed code is defined

### DIFF
--- a/angularjs/manageInstallCode/manage-install-tag-code.directive.html
+++ b/angularjs/manageInstallCode/manage-install-tag-code.directive.html
@@ -18,7 +18,7 @@
             <a href="{{ installInstruction.helpUrl }}" target="_blank" ng-show="installInstruction.helpUrl">{{ 'TagManager_LearnMore'|translate }}</a>
         </p>
 
-        <pre piwik-select-on-focus class="codeblock"
+        <pre piwik-select-on-focus class="codeblock"  ng-show="installInstruction.embedCode"
              ng-bind="installInstruction.embedCode">
         </pre>
     </div>


### PR DESCRIPTION
Allows plugins to add additional instructions with no embed code