### PR TITLE
fix: Tag::updateContainerTag setting a wrong startDate and endDate value

### DIFF
--- a/Model/Tag.php
+++ b/Model/Tag.php
@@ -145,8 +145,8 @@ class Tag extends BaseModel
                 'fire_limit' => $fireLimit,
                 'fire_delay' => $fireDelay,
                 'priority' => $priority,
-                'start_date' => $startDate,
-                'end_date' => $endDate
+                'start_date' => empty($startDate) ? null : $startDate,
+                'end_date' => empty($endDate) ? null : $endDate,
             );
             $this->updateTagColumns($idSite, $idContainerVersion, $idTag, $columns);
         }


### PR DESCRIPTION
When we do a tag update startDate and endDate is submitted as a empty
string that is converted to 0000-00-00 00:00:00 on database. That
conversion cause an ExceptionInvalidDateBeforeFirstWebsite exception
when We try to update tags again or publish a new version broken the
whole tagmanager plugin