### PR TITLE
Fix first trigger callback when tracker js is already loaded

### DIFF
--- a/Template/Tag/MatomoTag.web.js
+++ b/Template/Tag/MatomoTag.web.js
@@ -19,13 +19,19 @@
         window.piwikPluginAsyncInit = [];
     }
 
-    window.piwikPluginAsyncInit.push(function () {
-        libAvailable = true;
+    function executeCallbacks() {
 
         var i;
         for (i = 0; i < callbacks.callbacks.length; i++) {
             callbacks.callbacks[i]();
         }
+
+        callbacks.callbacks = [];
+    }
+
+    window.piwikPluginAsyncInit.push(function () {
+        libAvailable = true;
+        executeCallbacks();
     });
 
     function checkLoadedAlready()
@@ -33,6 +39,7 @@
         if (libAvailable || typeof window.Piwik === 'object') {
             libAvailable = true;
             libLoaded = true; // eg loaded by tests or manually by user
+            executeCallbacks();
             return true;
         }
         return false;


### PR DESCRIPTION
When the tracker js is already loaded before the container loads, the first trigger callback will not get called because libAvailable = false when inserting the callback.

This commit fixes this problem.