### PR TITLE
Fix idsite may be 0 in the container under circumstances

### DIFF
--- a/TagManager.php
+++ b/TagManager.php
@@ -32,6 +32,7 @@ use Piwik\Plugins\TagManager\Model\Container\ContainerIdGenerator;
 use Piwik\Plugins\TagManager\Model\Salt;
 use Piwik\Site;
 use Piwik\View;
+use Piwik\Context;
 
 class TagManager extends \Piwik\Plugin
 {
@@ -249,7 +250,9 @@ class TagManager extends \Piwik\Plugin
                 $containers = $containerModel->getActiveContainersInfo();
                 foreach ($containers as $container) {
                     try {
-                        $containerModel->generateContainer($container['idsite'], $container['idcontainer']);
+                        Context::changeIdSite($container['idsite'], function () use ($containerModel, $container) {
+                            $containerModel->generateContainer($container['idsite'], $container['idcontainer']);
+                        });
                     } catch (UnexpectedWebsiteFoundException $e) {
                         // website was removed, ignore
                     }


### PR DESCRIPTION
Make sure container generation is execute in the context of the configured site

@makarovstas I can't really think how this can happen except if the site was created through CLI or so. But even then I can't really think yet how this could happen. Could you try and test this change if this fixe the issue for you?

fix #203