### PR TITLE
When publishing a new version, and the version name is auto generated…

### DIFF
--- a/angularjs/manageVersion/edit.controller.js
+++ b/angularjs/manageVersion/edit.controller.js
@@ -109,6 +109,7 @@
 
                     if (self.create && !self.version.name && /^\d+$/.test(self.lastVersion)) {
                         self.version.name = parseInt(self.lastVersion, 10) + 1;
+                        self.isDirty = true;
                     }
                 }
             });


### PR DESCRIPTION
…, make sure the update button is active

When a user publishes a version named for example `1`. Then next time the user clicks on publish again we will automatically prefill `2` as version name. However, the `Update` button remains inactive so you are forced to make a change in order to click the button even though there is no change needed.