### PR TITLE
Set samesite flag (used in "preview mode" in tag manager container)

### DIFF
--- a/API/PreviewCookie.php
+++ b/API/PreviewCookie.php
@@ -8,7 +8,6 @@
 namespace Piwik\Plugins\TagManager\API;
 
 use Piwik\Cookie;
-use Piwik\ProxyHttp;
 
 class PreviewCookie extends Cookie
 {

--- a/API/PreviewCookie.php
+++ b/API/PreviewCookie.php
@@ -8,6 +8,7 @@
 namespace Piwik\Plugins\TagManager\API;
 
 use Piwik\Cookie;
+use Piwik\ProxyHttp;
 
 class PreviewCookie extends Cookie
 {
@@ -23,6 +24,16 @@ class PreviewCookie extends Cookie
     public function getCookieValueName($idSite, $idContainer)
     {
         return 'mtmPreview' . $idSite . '_' . $idContainer;
+    }
+
+    public function save($sameSite = null)
+    {
+        if (ProxyHttp::isHttps()) {
+            $this->setSecure(true);
+            parent::save('None');
+        } else {
+            parent::save('Lax');
+        }
     }
 
     public function enable($idSite, $idContainer)

--- a/API/PreviewCookie.php
+++ b/API/PreviewCookie.php
@@ -26,26 +26,16 @@ class PreviewCookie extends Cookie
         return 'mtmPreview' . $idSite . '_' . $idContainer;
     }
 
-    public function save($sameSite = null)
-    {
-        if (ProxyHttp::isHttps()) {
-            $this->setSecure(true);
-            parent::save('None');
-        } else {
-            parent::save('Lax');
-        }
-    }
-
     public function enable($idSite, $idContainer)
     {
         $this->set($this->getCookieValueName($idSite, $idContainer), '1');
-        $this->save();
+        $this->save('Lax');
     }
 
     public function disable($idSite, $idContainer)
     {
         $this->set($this->getCookieValueName($idSite, $idContainer), null);
-        $this->save();
+        $this->save('Lax');
     }
 
 }


### PR DESCRIPTION
refs https://github.com/matomo-org/matomo/issues/15672

The cookie is set when you enable "preview mode" in tag manager container.

It should always be fine to only use `Lax` since this feature only works anyway when Matomo and the website is running in the same domain. If they are not running in the same domain, people need to use `&mtmPreviewMode=$containerId` URL parameter