### PR TITLE
Unsanitize tag name in preview mode

### DIFF
--- a/Context/WebContext.php
+++ b/Context/WebContext.php
@@ -111,6 +111,8 @@ class WebContext extends BaseContext
                 $tag['parameters'] = $this->addVariableTemplateToParameters($tag['parameters']);
                 if (!$isPreviewRelease) {
                     $tag['name'] = md5($tag['name']);// actual name is needed for session/lifetime feature
+                } else {
+                    $tag['name'] = Common::unsanitizeInputValue($tag['name']);
                 }
             }
 
@@ -125,6 +127,8 @@ class WebContext extends BaseContext
                 }
                 if (!$isPreviewRelease) {
                     $trigger['name'] = $trigger['type'];
+                } else {
+                    $trigger['name'] = Common::unsanitizeInputValue($trigger['name']);
                 }
             }
 
@@ -134,6 +138,8 @@ class WebContext extends BaseContext
 
                 if (!$isPreviewRelease) {
                     $variable['name'] = $variable['type'];
+                } else {
+                    $variable['name'] = Common::unsanitizeInputValue($variable['name']);
                 }
             }
 


### PR DESCRIPTION
fix https://github.com/matomo-org/tag-manager/issues/230

The tag/trigger/variable names are stored sanitized so for them to appear correctly in the preview they need to be unsanitzed. Angular should take care of the escaping in `debug.twig` template.