### PR TITLE
Set idSite on tracker already when creating the tracker

### DIFF
--- a/Template/Tag/MatomoTag.web.js
+++ b/Template/Tag/MatomoTag.web.js
@@ -111,9 +111,9 @@
                     lastMatomoUrl = getMatomoUrlFromConfig(matomoConfig);
                     var trackerUrl = lastMatomoUrl + matomoConfig.trackingEndpoint;
                     if (matomoConfig.registerAsDefaultTracker) {
-                        tracker = Piwik.addTracker(trackerUrl);
+                        tracker = Piwik.addTracker(trackerUrl, matomoConfig.idSite);
                     } else {
-                        tracker = Piwik.getTracker(trackerUrl);
+                        tracker = Piwik.getTracker(trackerUrl, matomoConfig.idSite);
                     }
                     configuredTrackers[variableName] = tracker;
 
@@ -155,8 +155,6 @@
                         tracker.setDomains(domains);
                     }
 
-                    tracker.setSiteId(matomoConfig.idSite);
-                    
                     if (matomoConfig.alwaysUseSendBeacon) {
                         tracker.alwaysUseSendBeacon();
                     }


### PR DESCRIPTION
Since Matomo 3.14.0 the cookies are no longer when setting idSite allowing us to configure the idSite early. Before, when calling `setIdSite`, it was directly creating cookies even though no cookie domain etc was created yet.

As a result, when the `TrackerAdded` event is triggered, then all the listeners will receive the tracker fully configured with idSite and tracker URL instead of only the URL. In particular this fixes eg Heatmaps & Session Recording when there are 2 trackers used in one container. Then currently, the second tracker was not requesting `configs.php` and was not checking for heatmaps or session recordings because at the time `TrackerAdded` was triggered, there was not yet an idSite configured.

![image](https://user-images.githubusercontent.com/273120/87723095-61d99180-c80d-11ea-932a-c7937517bad7.png)
