### PR TITLE
Avoid minification while testing

### DIFF
--- a/Template/BaseTemplate.php
+++ b/Template/BaseTemplate.php
@@ -9,6 +9,7 @@ namespace Piwik\Plugins\TagManager\Template;
 
 use JShrink\Minifier;
 use Piwik\Common;
+use Piwik\Container\StaticContainer;
 use Piwik\Development;
 use Piwik\Piwik;
 use Piwik\Plugins\CorePluginsAdmin\SettingsMetadata;
@@ -206,7 +207,9 @@ abstract class BaseTemplate
                 $file = $base . 'web.js';
                 $minFile = $base . 'web.min.js';
 
-                if (Development::isEnabled() && $this->hasTemplateFile($file)) {
+                if (!StaticContainer::get('TagManagerJSMinificationEnabled')) {
+                    return $this->loadTemplateFile($file); // avoid minification in test mode
+                } elseif (Development::isEnabled() && $this->hasTemplateFile($file)) {
                     // during dev mode we prefer the non-minified version for debugging purposes, but we still use
                     // the internal minifier to make sure we debug the same as a user would receive
                     $template = $this->loadTemplateFile($file);

--- a/config/config.php
+++ b/config/config.php
@@ -14,6 +14,7 @@ return array(
         // the prefix for any container file
         return 'container_';
     },
+    'TagManagerJSMinificationEnabled' => true,
     'fileintegrity.ignore' => DI\add(array(
         DI\get('fileintegrityIgnoreTagManager')
     )),

--- a/config/test.php
+++ b/config/test.php
@@ -18,5 +18,6 @@ return array(
                 $stylesheets[] = 'plugins/TagManager/tests/resources/uitest-override.css';
             }
         })),
-    ))
+    )),
+    'TagManagerJSMinificationEnabled' => false,
 );

--- a/tests/Integration/Template/BaseTemplateTest.php
+++ b/tests/Integration/Template/BaseTemplateTest.php
@@ -143,5 +143,10 @@ class BaseTemplateTest extends IntegrationTestCase
         $this->assertSame($expected, $this->template->toArray());
     }
 
-
+    public function provideContainerConfig()
+    {
+        return array(
+            'TagManagerJSMinificationEnabled' => true
+        );
+    }
 }

--- a/tests/System/ContextTest.php
+++ b/tests/System/ContextTest.php
@@ -549,7 +549,8 @@ var seoMetaDescriptionHelloWorld = "{{Referrer}}";
             },
             'Piwik\Plugins\TagManager\Model\Salt' => function () {
                 return new Salt(sha1('foobar'));
-            }
+            },
+            'TagManagerJSMinificationEnabled' => true
         );
     }
 }


### PR DESCRIPTION
Minifying the javascript files takes only a bit, but isn't actually needed at all while running tests. It doesn't speed up the TagManager tests, but Core tests are running a bit faster, as various TagManager methods are triggered multiple times while setting up fixtures.

_For example: while setting up UITestFixture `JShrink:minify` is called 152 times._