### PR TITLE
Fix return value of usort

### DIFF
--- a/Dao/TagsDao.php
+++ b/Dao/TagsDao.php
@@ -206,7 +206,7 @@ class TagsDao extends BaseDao implements TagManagerDao
                 $indexB = array_search($tagB, $tags);
                 return $indexA - $indexB;
             }
-            return $tagA['priority'] > $tagB['priority'];
+            return strcasecmp($tagB['priority'], $tagA['priority']);
         });
 
         return $tags;

--- a/Dao/TagsDao.php
+++ b/Dao/TagsDao.php
@@ -200,7 +200,7 @@ class TagsDao extends BaseDao implements TagManagerDao
         }
 
         usort($tags, function ($tagA, $tagB) use ($tags) {
-            return strcasecmp($tagB['priority'], $tagA['priority']);
+            return strcasecmp($tagA['priority'], $tagB['priority']);
         });
 
         return $tags;

--- a/Dao/TagsDao.php
+++ b/Dao/TagsDao.php
@@ -200,12 +200,6 @@ class TagsDao extends BaseDao implements TagManagerDao
         }
 
         usort($tags, function ($tagA, $tagB) use ($tags) {
-            if ($tagA['priority'] === $tagB['priority']) {
-                // for php5 making sure to have same sort order as on php7
-                $indexA = array_search($tagA, $tags);
-                $indexB = array_search($tagB, $tags);
-                return $indexA - $indexB;
-            }
             return strcasecmp($tagB['priority'], $tagA['priority']);
         });
 


### PR DESCRIPTION
Returning other values than integer triggers a deprecation on PHP 8

Running tests on PHP 8 triggers this a lot:

```
Deprecated: usort(): Returning bool from comparison function is deprecated, return an integer less than, equal to, or greater than zero in /home/travis/build/matomo-org/matomo/plugins/TagManager/Dao/TagsDao.php on line 210
```