### PR TITLE
Detect when variable references itself

### DIFF
--- a/Context/BaseContext.php
+++ b/Context/BaseContext.php
@@ -10,6 +10,7 @@ namespace Piwik\Plugins\TagManager\Context;
 use Piwik\Common;
 use Piwik\Container\StaticContainer;
 use Piwik\Plugins\TagManager\Context\Storage\StorageInterface;
+use Piwik\Plugins\TagManager\Exception\EntityRecursionException;
 use Piwik\Plugins\TagManager\Model\Container;
 use Piwik\Plugins\TagManager\Model\Environment;
 use Piwik\Plugins\TagManager\Model\Salt;
@@ -166,7 +167,7 @@ abstract class BaseContext
             // eg MatomoConfiguration variable referencing itself in a variable like matomoUrl=https://matomo.org{{MatomoConfiguration}}
             $entries = array_slice($this->nestedVariableCals, -3); // show last 3 entities in error message
             $entries = array_unique($entries);
-            throw new \Exception('It seems an entity references itself or a recursion is caused in some other way. It may be related due to these entites: "'.implode(',', $entries). '". Please check if the entity references itself maybe or if a recursion might happen in another way.');
+            throw new EntityRecursionException('It seems an entity references itself or a recursion is caused in some other way. It may be related due to these entites: "'.implode(',', $entries). '". Please check if the entity references itself maybe or if a recursion might happen in another way.');
         }
 
         $parameters = $entity['parameters'];

--- a/Context/BaseContext.php
+++ b/Context/BaseContext.php
@@ -161,7 +161,9 @@ abstract class BaseContext
 
     private function parametersToVariableJs($container, $entity)
     {
-        $this->nestedVariableCals[] = $entity['name'];
+        if (!empty($entity['name'])) {
+            $this->nestedVariableCals[] = $entity['name'];
+        }
 
         if (count($this->nestedVariableCals) > 500) {
             // eg MatomoConfiguration variable referencing itself in a variable like matomoUrl=https://matomo.org{{MatomoConfiguration}}
@@ -224,7 +226,9 @@ abstract class BaseContext
             }
         }
 
-        array_pop($this->nestedVariableCals);
+        if (!empty($entity['name'])) {
+            array_pop($this->nestedVariableCals);
+        }
 
         return $vars;
     }

--- a/Exception/EntityRecursionException.php
+++ b/Exception/EntityRecursionException.php
@@ -1,0 +1,14 @@
+<?php
+/**
+ * Matomo - free/libre analytics platform
+ *
+ * @link https://matomo.org
+ * @license http://www.gnu.org/licenses/gpl-3.0.html GPL v3 or later
+ */
+
+namespace Piwik\Plugins\TagManager\Exception;
+
+
+class EntityRecursionException extends \Exception
+{
+}

--- a/SimulatorContext.php
+++ b/SimulatorContext.php
@@ -1,0 +1,48 @@
+<?php
+/**
+ * Matomo - free/libre analytics platform
+ *
+ * @link https://matomo.org
+ * @license http://www.gnu.org/licenses/gpl-3.0.html GPL v3 or later
+ */
+namespace Piwik\Plugins\TagManager;
+
+use Piwik\Plugins\TagManager\Context\BaseContext;
+
+// we don't have this context in the "Context" directory of this plugin because we don't want it to be picked up as a component
+// we only want to use it to detect whether a variable references itself or if there is any recursion
+class SimulatorContext extends BaseContext
+{
+    const ID = 'simulator';
+
+    public function getId()
+    {
+        return self::ID;
+    }
+
+    public function getName()
+    {
+        return 'Simulator';
+    }
+
+    public function getOrder()
+    {
+        return 15;
+    }
+
+    public function generate($container)
+    {
+        foreach ($container['releases'] as $release) {
+            // we don't actually look at the output and we also don't save anything
+            // we only simulate the core logic of any container generation
+            $this->generatePublicContainer($container, $release);
+        }
+        return [];
+    }
+
+    public function getInstallInstructions($container, $environment)
+    {
+        return [];
+    }
+
+}

--- a/tests/Integration/Context/WebContextTest.php
+++ b/tests/Integration/Context/WebContextTest.php
@@ -8,89 +8,134 @@
 
 namespace Piwik\Plugins\TagManager\tests\Integration\Context;
 
-use Piwik\API\Request;
 use Piwik\Container\StaticContainer;
-use Piwik\Piwik;
+use Piwik\Plugins\TagManager\API;
 use Piwik\Plugins\TagManager\Context\WebContext;
+use Piwik\Plugins\TagManager\Dao\VariablesDao;
+use Piwik\Plugins\TagManager\Exception\EntityRecursionException;
 use Piwik\Plugins\TagManager\Model\Container;
+use Piwik\Plugins\TagManager\TagManager;
 use Piwik\Plugins\TagManager\Template\Variable\MatomoConfigurationVariable;
 use Piwik\Plugins\TagManager\tests\Framework\TestCase\IntegrationTestCase;
 use Piwik\Tests\Framework\Fixture;
 
 /**
  * @group TagManager
- * @group WebContextx
+ * @group WebContext
+ * @group API
  * @group WebContextTest
+ * @group APITest
  * @group Plugins
  */
 class WebContextTest extends IntegrationTestCase
 {
+    /**
+     * @var int
+     */
     private $idSite;
+
+    /**
+     * @var API
+     */
+    private $api;
+
     public function setUp(): void
     {
         parent::setUp();
 
+        TagManager::$enableAutoContainerCreation = false;
         $this->idSite = Fixture::createWebsite('2014-01-01 02:03:04');
+        $this->api = API::getInstance();
     }
 
-    private function setupContainerWithRecursion($enablePreviewMode)
+    public function tearDown(): void
     {
-        $idContainer = Request::processRequest(
-            'TagManager.addContainer',
-            [
-                'idSite' => $this->idSite,
-                'context' => WebContext::ID,
-                'name' => 'test'
-            ]
-        );
+        TagManager::$enableAutoContainerCreation = false;
+        parent::tearDown();
+    }
 
-        if ($enablePreviewMode) {
-            Request::processRequest(
-                'TagManager.enablePreviewMode',
-                array(
-                    'idSite' => $this->idSite,
-                    'idContainer' => $idContainer,
-                ),
-                $default = []
-            );
-        }
-
+    private function getContainerDraftVersion($idContainer)
+    {
         $containers = StaticContainer::get(Container::class);
         $containerVersion = $containers->getContainer($this->idSite, $idContainer);
         $idContainerVersion = null;
         if (!empty($containerVersion['draft']['idcontainerversion'])) {
             $idContainerVersion =  $containerVersion['draft']['idcontainerversion'];
         }
-        Request::processRequest(
-            'TagManager.addContainerVariable',
-            array(
-                'idSite' => $this->idSite,
-                'idContainer' => $idContainer,
-                'idContainerVersion' => $idContainerVersion,
-                'type' => MatomoConfigurationVariable::ID,
-                'name' => Piwik::translate('TagManager_MatomoConfigurationVariableName'),
-                'parameters' => ['matomoUrl' => 'https://matomo.org{{Matomo Configuration}}']
-            ),
-            $default = []
-        );
+        return $idContainerVersion;
+    }
+
+    private function setupContainerWithRecursion($enablePreviewMode)
+    {
+        $idContainer = $this->api->addContainer($this->idSite, WebContext::ID, 'test');
+
+        if ($enablePreviewMode) {
+            $this->api->enablePreviewMode($this->idSite, $idContainer);
+        }
+
+        $idContainerVersion = $this->getContainerDraftVersion($idContainer);
+        $this->api->addContainerVariable($this->idSite, $idContainer, $idContainerVersion, MatomoConfigurationVariable::ID, 'MyVar',
+            ['matomoUrl' => 'https://matomo.org{{MyVar}}', 'idSite' => $this->idSite]);
 
         return $idContainer;
     }
 
     public function test_detectsRecursion_whenPreviewModeEnabled()
     {
-        $this->expectException(\Exception::class);
-        $this->expectExceptionMessage('It seems an entity references itself or a recursion is caused in some other way. It may be related due to these entites: "Matomo Configuration"');
+        $this->expectException(EntityRecursionException::class);
+        $this->expectExceptionMessage('It seems an entity references itself or a recursion is caused in some other way. It may be related due to these entites: "MyVar"');
 
         $this->setupContainerWithRecursion($enablePreviewMode = true);
     }
 
     public function test_detectsRecursion_whenPreviewModeNotEnabled()
     {
-        $this->expectException(\Exception::class);
-        $this->expectExceptionMessage('It seems an entity references itself or a recursion is caused in some other way. It may be related due to these entites: "Matomo Configuration"');
+        $this->expectException(EntityRecursionException::class);
+        $this->expectExceptionMessage('It seems an entity references itself or a recursion is caused in some other way. It may be related due to these entites: "MyVar"');
 
         $this->setupContainerWithRecursion($enablePreviewMode = false);
+    }
+
+    public function test_detectsRecursion_addVarialbeWillDeleteTheVariable()
+    {
+        try {
+            $this->setupContainerWithRecursion($enablePreviewMode = false);
+        } catch (EntityRecursionException $e) {
+
+            $dao = new VariablesDao();
+            $var = $dao->getAllVariables();
+            $this->assertEquals('deleted', $var[0]['status']);
+            $this->assertEquals('MyVar', $var[0]['name']);
+            $this->assertCount(1, $var);
+            return;
+        }
+
+        $this->fail('An expected exception has not been thrown');
+    }
+
+    public function test_detectsRecursion_updateVariableWillRestoreOriginalValueWhenRecursionDetected()
+    {
+        $idContainer = $this->api->addContainer($this->idSite, WebContext::ID, 'test');
+        $idContainerVersion = $this->getContainerDraftVersion($idContainer);
+        $idVariable = $this->api->addContainerVariable($this->idSite, $idContainer, $idContainerVersion, MatomoConfigurationVariable::ID, 'MyVar',
+            ['matomoUrl' => 'https://matomo.org', 'idSite' => $this->idSite]);
+
+        try {
+
+            $this->api->updateContainerVariable($this->idSite, $idContainer, $idContainerVersion, $idVariable,
+                'MyVar2', ['matomoUrl' => 'https://matomo.org{{MyVar2}}', 'idSite' => $this->idSite]);
+        } catch (EntityRecursionException $e) {
+
+            $dao = new VariablesDao();
+            $var = $dao->getAllVariables();
+            $this->assertEquals('active', $var[0]['status']);
+            $this->assertEquals('MyVar', $var[0]['name']);
+            $this->assertEquals('https://matomo.org', $var[0]['parameters']['matomoUrl']);
+            $this->assertCount(1, $var);
+            return;
+        }
+
+        $this->fail('An expected exception has not been thrown');
     }
 
 }

--- a/tests/Integration/Context/WebContextTest.php
+++ b/tests/Integration/Context/WebContextTest.php
@@ -1,0 +1,81 @@
+<?php
+/**
+ * Matomo - free/libre analytics platform
+ *
+ * @link https://matomo.org
+ * @license http://www.gnu.org/licenses/gpl-3.0.html GPL v3 or later
+ */
+
+namespace Piwik\Plugins\TagManager\tests\Integration\Context;
+
+use Piwik\API\Request;
+use Piwik\Container\StaticContainer;
+use Piwik\Piwik;
+use Piwik\Plugins\TagManager\Context\WebContext;
+use Piwik\Plugins\TagManager\Model\Container;
+use Piwik\Plugins\TagManager\Template\Variable\MatomoConfigurationVariable;
+use Piwik\Plugins\TagManager\tests\Framework\TestCase\IntegrationTestCase;
+use Piwik\Tests\Framework\Fixture;
+
+/**
+ * @group TagManager
+ * @group WebContextx
+ * @group WebContextTest
+ * @group Plugins
+ */
+class WebContextTest extends IntegrationTestCase
+{
+    private $idSite;
+    public function setUp(): void
+    {
+        parent::setUp();
+
+        $this->idSite = Fixture::createWebsite('2014-01-01 02:03:04');
+    }
+
+    public function test_detectsRecursion()
+    {
+        $this->expectException(\Exception::class);
+        $this->expectExceptionMessage('It seems an entity references itself or a recursion is caused in some other way. It may be related due to these entites: "Matomo Configuration"');
+
+        $idContainer = Request::processRequest(
+            'TagManager.addContainer',
+            [
+                'idSite' => $this->idSite,
+                'context' => WebContext::ID,
+                'name' => 'test'
+            ]
+        );
+
+        $containers = StaticContainer::get(Container::class);
+        $containerVersion = $containers->getContainer($this->idSite, $idContainer);
+        $idContainerVersion = null;
+        if (!empty($containerVersion['draft']['idcontainerversion'])) {
+            $idContainerVersion =  $containerVersion['draft']['idcontainerversion'];
+        }
+        Request::processRequest(
+            'TagManager.addContainerVariable',
+            array(
+                'idSite' => $this->idSite,
+                'idContainer' => $idContainer,
+                'idContainerVersion' => $idContainerVersion,
+                'type' => MatomoConfigurationVariable::ID,
+                'name' => Piwik::translate('TagManager_MatomoConfigurationVariableName'),
+                'parameters' => ['matomoUrl' => 'https://matomo.org{{Matomo Configuration}}']
+            ),
+            $default = []
+        );
+
+        Request::processRequest(
+            'TagManager.enablePreviewMode',
+            array(
+                'idSite' => $this->idSite,
+                'idContainer' => $idContainer,
+            ),
+            $default = []
+        );
+
+        $containers->generateContainer($this->idSite, $idContainer);
+    }
+
+}


### PR DESCRIPTION
To reproduce this initially: 
Eg create a MatomoConfiguration variable named "Matomo Configuration" and set Matomo URL to "https://matomo.org{{Matomo Configuration}}".

If no preview mode is enabled, we now "simulate" a basic container generation without saving it anywhere or doing anything with it just to detect such issues.
