### PR TITLE
Prevent possible circular reference in preview mode in addDebugValues

### DIFF
--- a/javascripts/tagmanager.js
+++ b/javascripts/tagmanager.js
@@ -1485,7 +1485,13 @@
 
                     container.id = this.id;
                     container.versionName = this.versionName;
-                    container.dataLayer = JSON.parse(JSON.stringify(this.dataLayer.values));
+                    container.dataLayer = JSON.parse(JSON.stringify(this.dataLayer.values, function( key, value) {
+                        if (typeof value === 'object' && value instanceof Node) {
+                            return value.nodeName;
+                        } else {
+                            return value;
+                        };
+                    }));
                 };
 
                 this.getTriggerById = function (idTrigger){


### PR DESCRIPTION
Prevent "TypeError: Converting circular structure to JSON" similar to https://github.com/matomo-org/tag-manager/pull/186fpr html elements in the data layer.

React.js does set circular references to the dom elements, which lead JSON.stringify to fail them:

<img width="1273" alt="Bildschirmfoto 2021-01-18 um 08 29 40" src="https://user-images.githubusercontent.com/7815946/104886426-04fc9680-596a-11eb-949a-1021cde9113f.png">
