### PR TITLE
Ensure container update only sends required parameters as POST

### DIFF
--- a/angularjs/manageContainer/model.js
+++ b/angularjs/manageContainer/model.js
@@ -128,7 +128,7 @@
                 }
             });
 
-            var postParams = ['idContainer', 'name', 'description'];
+            var postParams = ['idContainer', 'name', 'description', 'context'];
             var post = {};
             for (var i = 0; i < postParams.length; i++) {
                 var param = postParams[i];

--- a/angularjs/manageContainer/model.js
+++ b/angularjs/manageContainer/model.js
@@ -116,7 +116,6 @@
 
         function createOrUpdateContainer(container, method) {
             container = angular.copy(container);
-            container.method = method;
 
             var map = {
                 idContainer: 'idcontainer',
@@ -129,13 +128,12 @@
                 }
             });
 
-            var postParams = [];
+            var postParams = ['idContainer', 'name', 'description'];
             var post = {};
             for (var i = 0; i < postParams.length; i++) {
-                var postParam = postParams[i];
-                if (typeof container[postParam] !== 'undefined') {
-                    post[postParam] = container[postParam];
-                    delete container[postParam];
+                var param = postParams[i];
+                if (typeof container[param] !== 'undefined') {
+                    post[param] = container[param];
                 }
             }
 
@@ -143,7 +141,7 @@
 
             piwikApi.withTokenInUrl();
 
-            return piwikApi.post(container, post).then(function (response) {
+            return piwikApi.post({method: method}, post).then(function (response) {
                 model.isUpdating = false;
 
                 return {type: 'success', response: response};


### PR DESCRIPTION
The angular model was actually sending all attributes of a container, which also included the list of releases. As the update actually only requires a few parameters, it should be better to only send those.

Maybe some other forms might have similar issues...

fixes #309 