### PR TITLE
Implemented Intersection Observer to fire visibility trigger along with scroll and DOM load

### DIFF
--- a/Template/Trigger/ElementVisibilityTrigger.web.js
+++ b/Template/Trigger/ElementVisibilityTrigger.web.js
@@ -243,22 +243,24 @@
         }
 
         function setIntersectionObserver(triggerEvent) {
-            if ('IntersectionObserver' in window) {
-                var interSectionObserverOptions = {
-                    root: null, // document's viewport as the container.
-                    rootMargin: '0px',
-                    threshold: (minPercentVisible / 100)
-                };
-                observerIntersection = new IntersectionObserver(function (entries) {
-                    interSectionCallback(entries, triggerEvent);
-                }, interSectionObserverOptions);
+            return function () {
+                if ('IntersectionObserver' in window) {
+                    var interSectionObserverOptions = {
+                        root: null, // document's viewport as the container.
+                        rootMargin: '0px',
+                        threshold: (minPercentVisible / 100)
+                    };
+                    observerIntersection = new IntersectionObserver(function (entries) {
+                        interSectionCallback(entries, triggerEvent);
+                    }, interSectionObserverOptions);
 
-                if (selectors) {
-                    TagManager.dom.bySelector(selectors).forEach(function (element) {
-                        observerIntersection.observe(element);
-                    });
+                    if (selectors) {
+                        TagManager.dom.bySelector(selectors).forEach(function (element) {
+                            observerIntersection.observe(element);
+                        });
+                    }
                 }
-            }
+            };
 
         }
 

--- a/Template/Trigger/ElementVisibilityTrigger.web.js
+++ b/Template/Trigger/ElementVisibilityTrigger.web.js
@@ -10,234 +10,68 @@
         var utils = TagManager.utils;
         var blockTrigger = false;
         var onlyOncePerElement = fireTriggerWhen === 'onceElement';
+        var selectors = getSelectors();
 
-        function getPercentVisible(node)
-        {
-            if (!node || !node.getBoundingClientRect) {
-                return 0;
+        function setIntersectionObserver(triggerEvent) {
+            if ('IntersectionObserver' in window) {
+                var interSectionObserverOptions = {
+                    root: null,
+                    rootMargin: '0px',
+                    threshold: (minPercentVisible / 100)
+                };
+                var observerIntersection = new IntersectionObserver(function (entries) {
+                    interSectionCallback(entries, triggerEvent, observerIntersection);
+                }, interSectionObserverOptions);
+
+                if (selectors) {
+                    TagManager.dom.bySelector(selectors).forEach(function (element) {
+                        observerIntersection.observe(element);
+                    });
+                }
             }
-            var nodeRect = node.getBoundingClientRect();
-            var winRect = {height: parameters.window.innerHeight, width: parameters.window.innerWidth};
-
-            var visHeight = 0;
-            var visWidth = 0;
-
-            if (nodeRect.left >= 0) {
-                visWidth = Math.min(nodeRect.width, winRect.width - nodeRect.left);
-            } else if (nodeRect.right > 0) {
-                visWidth = Math.min(winRect.width, nodeRect.right);
-            } else {
-                return 0;
-            }
-
-            if (nodeRect.top >= 0) {
-                visHeight = Math.min(nodeRect.height, winRect.height - nodeRect.top);
-            } else if (nodeRect.bottom > 0) {
-                visHeight = Math.min(winRect.height, nodeRect.bottom);
-            } else {
-                return 0;
-            }
-
-            var vis = visHeight * visWidth;
-            var ele = nodeRect.height * nodeRect.width;
-
-            if (!ele) {
-                return 0;
-            }
-
-            return (vis / ele) * 100;
+            
         }
 
-        /************************************************************
-         * Element Visiblility
-         ************************************************************/
+        function interSectionCallback(entries, triggerEvent, observer) {
+            var dom = TagManager.dom;
+            entries.forEach(function (entry) {
+                if (entry.intersectionRatio > 0) {
+                    triggerEvent({
+                        event: 'mtm.ElementVisibility',
+                        'mtm.elementVisibilityPercentage': minPercentVisible,
+                        'mtm.elementVisibilityId': dom.getElementAttribute(entry.target, 'id'),
+                        'mtm.elementVisibilityClasses': dom.getElementClassNames(entry.target),
+                        'mtm.elementVisibilityText': TagManager.utils.trim(entry.target.innerText),
+                        'mtm.elementVisibilityNodeName': entry.target.nodeName,
+                        'mtm.elementVisibilityUrl': entry.target.href || dom.getElementAttribute(entry.target, 'href'),
+                    });
 
-        /**
-         * Author: Jason Farrell
-         * Author URI: http://useallfive.com/
-         *
-         * Description: Checks if a DOM element is truly visible.
-         * Package URL: https://github.com/UseAllFive/true-visibility
-         * License: MIT (https://github.com/UseAllFive/true-visibility/blob/master/LICENSE.txt)
-         */
-        function isVisible(node) {
-
-            if (!node) {
-                return false;
-            }
-
-            //-- Cross browser method to get style properties:
-            function _getStyle(el, property) {
-                if (windowAlias.getComputedStyle) {
-                    return documentAlias.defaultView.getComputedStyle(el,null)[property];
-                }
-                if (el.currentStyle) {
-                    return el.currentStyle[property];
-                }
-            }
-
-            function _elementInDocument(element) {
-                element = element.parentNode;
-
-                while (element) {
-                    if (element === documentAlias) {
-                        return true;
+                    if (fireTriggerWhen === 'oncePage') {
+                        TagManager.dom.bySelector(selectors).forEach(function (element) {
+                            observer.unobserve(element);
+                            triggeredNodes.push(element);
+                        });
+                    } else if(onlyOncePerElement) {
+                        observer.unobserve(entry.target);
+                        triggeredNodes.push(entry.target); // to avoid possible memory leaks as much as possible we add onceElement only when needed
                     }
-                    element = element.parentNode;
                 }
-                return false;
-            }
-
-            /**
-             * Checks if a DOM element is visible. Takes into
-             * consideration its parents and overflow.
-             *
-             * @param (el)      the DOM element to check if is visible
-             *
-             * These params are optional that are sent in recursively,
-             * you typically won't use these:
-             *
-             * @param (t)       Top corner position number
-             * @param (r)       Right corner position number
-             * @param (b)       Bottom corner position number
-             * @param (l)       Left corner position number
-             * @param (w)       Element width number
-             * @param (h)       Element height number
-             */
-            function _isVisible(el, t, r, b, l, w, h) {
-                var p = el.parentNode,
-                    VISIBLE_PADDING = 1; // has to be visible at least one px of the element
-
-                if (!_elementInDocument(el)) {
-                    return false;
-                }
-
-                //-- Return true for document node
-                if (9 === p.nodeType) {
-                    return true;
-                }
-
-                //-- Return false if our element is invisible
-                if (
-                    '0' === _getStyle(el, 'opacity') ||
-                    'none' === _getStyle(el, 'display') ||
-                    'hidden' === _getStyle(el, 'visibility')
-                ) {
-                    return false;
-                }
-
-                if (!utils.isDefined(t) ||
-                    !utils.isDefined(r) ||
-                    !utils.isDefined(b) ||
-                    !utils.isDefined(l) ||
-                    !utils.isDefined(w) ||
-                    !utils.isDefined(h)) {
-                    t = el.offsetTop;
-                    l = el.offsetLeft;
-                    b = t + el.offsetHeight;
-                    r = l + el.offsetWidth;
-                    w = el.offsetWidth;
-                    h = el.offsetHeight;
-                }
-
-                if (node === el && (0 === h || 0 === w) && 'hidden' === _getStyle(el, 'overflow')) {
-                    return false;
-                }
-
-                //-- If we have a parent, let's continue:
-                if (p) {
-                    //-- Check if the parent can hide its children.
-                    if (('hidden' === _getStyle(p, 'overflow') || 'scroll' === _getStyle(p, 'overflow'))) {
-                        //-- Only check if the offset is different for the parent
-                        if (
-                            //-- If the target element is to the right of the parent elm
-                        l + VISIBLE_PADDING > p.offsetWidth + p.scrollLeft ||
-                        //-- If the target element is to the left of the parent elm
-                        l + w - VISIBLE_PADDING < p.scrollLeft ||
-                        //-- If the target element is under the parent elm
-                        t + VISIBLE_PADDING > p.offsetHeight + p.scrollTop ||
-                        //-- If the target element is above the parent elm
-                        t + h - VISIBLE_PADDING < p.scrollTop
-                        ) {
-                            //-- Our target element is out of bounds:
-                            return false;
-                        }
-                    }
-                    //-- Add the offset parent's left/top coords to our element's offset:
-                    if (el.offsetParent === p) {
-                        l += p.offsetLeft;
-                        t += p.offsetTop;
-                    }
-                    //-- Let's recursively check upwards:
-                    return _isVisible(p, t, r, b, l, w, h);
-                }
-                return true;
-            }
-
-            return _isVisible(node);
+            });
         }
 
-        function checkVisiblity (triggerEvent) {
-            return function (event) {
-                if (blockTrigger) {
-                    // oncePerPage trigger only. do not trigger it again
-                    return;
-                }
-                var nodes = [];
-                var selectionMethod = parameters.get('selectionMethod');
+        function getSelectors() {
+            var selectionMethod = parameters.get('selectionMethod');
+            if (selectionMethod === 'elementId') {
+                return '#' + parameters.get('elementId');
+            } else if (selectionMethod === 'cssSelector') {
+                return parameters.get('cssSelector');
+            }
 
-                var dom = TagManager.dom;
-
-                if (selectionMethod === 'elementId') {
-                    var node = dom.byId(parameters.get('elementId'));
-                    if (node) {
-                        nodes.push(node);
-                    }
-                } else if (selectionMethod === 'cssSelector') {
-                    nodes = dom.bySelector(parameters.get('cssSelector'));
-                } else {
-                    return;
-                }
-
-                for (var i = 0; i < nodes.length; i++) {
-                    if (onlyOncePerElement) {
-                        var hasNodeBeenTriggered = false;
-                        for (var j = 0; j < triggeredNodes.length; j++) {
-                            if (nodes[i] === triggeredNodes[j]) {
-                                hasNodeBeenTriggered = true;
-                            }
-                        }
-                        if (hasNodeBeenTriggered) {
-                            continue;
-                        }
-                    }
-                    if (nodes[i] && isVisible(nodes[i])) {
-                        var percentVisible = getPercentVisible(nodes[i]);
-                        if (!minPercentVisible || minPercentVisible <= percentVisible) {
-                            triggerEvent({
-                                event: 'mtm.ElementVisibility',
-                                'mtm.elementVisibilityPercentage': Math.round(percentVisible * 100) / 100,
-                                'mtm.elementVisibilityId': dom.getElementAttribute(nodes[i], 'id'),
-                                'mtm.elementVisibilityClasses': dom.getElementClassNames(nodes[i]),
-                                'mtm.elementVisibilityText': TagManager.utils.trim(nodes[i].innerText),
-                                'mtm.elementVisibilityNodeName': nodes[i].nodeName,
-                                'mtm.elementVisibilityUrl': nodes[i].href || dom.getElementAttribute(nodes[i], 'href'),
-                            });
-                            if (fireTriggerWhen === 'oncePage') {
-                                blockTrigger = true;
-                                TagManager.window.offScroll(self.scrollIndex);
-                            } else if (onlyOncePerElement) {
-                                triggeredNodes.push(nodes[i]); // to avoid possible memory leaks as much as possible we add onceElement only when needed
-                            }
-                        }
-                    }
-                }
-            };
+            return;
         }
 
         this.setUp = function (triggerEvent) {
-            this.scrollIndex = TagManager.window.onScroll(checkVisiblity(triggerEvent));
-            TagManager.dom.onLoad(checkVisiblity(triggerEvent));
+            setIntersectionObserver(triggerEvent);
         };
     };
 })();

--- a/Template/Trigger/ElementVisibilityTrigger.web.js
+++ b/Template/Trigger/ElementVisibilityTrigger.web.js
@@ -12,51 +12,222 @@
         var onlyOncePerElement = fireTriggerWhen === 'onceElement';
         var selectors = getSelectors();
 
-        function setIntersectionObserver(triggerEvent) {
-            if ('IntersectionObserver' in window) {
-                var interSectionObserverOptions = {
-                    root: null,
-                    rootMargin: '0px',
-                    threshold: (minPercentVisible / 100)
-                };
-                var observerIntersection = new IntersectionObserver(function (entries) {
-                    interSectionCallback(entries, triggerEvent, observerIntersection);
-                }, interSectionObserverOptions);
-
-                if (selectors) {
-                    TagManager.dom.bySelector(selectors).forEach(function (element) {
-                        observerIntersection.observe(element);
-                    });
-                }
+        function getPercentVisible(node)
+        {
+            if (!node || !node.getBoundingClientRect) {
+                return 0;
             }
-            
+            var nodeRect = node.getBoundingClientRect();
+            var winRect = {height: parameters.window.innerHeight, width: parameters.window.innerWidth};
+
+            var visHeight = 0;
+            var visWidth = 0;
+
+            if (nodeRect.left >= 0) {
+                visWidth = Math.min(nodeRect.width, winRect.width - nodeRect.left);
+            } else if (nodeRect.right > 0) {
+                visWidth = Math.min(winRect.width, nodeRect.right);
+            } else {
+                return 0;
+            }
+
+            if (nodeRect.top >= 0) {
+                visHeight = Math.min(nodeRect.height, winRect.height - nodeRect.top);
+            } else if (nodeRect.bottom > 0) {
+                visHeight = Math.min(winRect.height, nodeRect.bottom);
+            } else {
+                return 0;
+            }
+
+            var vis = visHeight * visWidth;
+            var ele = nodeRect.height * nodeRect.width;
+
+            if (!ele) {
+                return 0;
+            }
+
+            return (vis / ele) * 100;
         }
 
-        function interSectionCallback(entries, triggerEvent, observer) {
-            var dom = TagManager.dom;
-            entries.forEach(function (entry) {
-                if (entry.intersectionRatio > 0) {
-                    triggerEvent({
-                        event: 'mtm.ElementVisibility',
-                        'mtm.elementVisibilityPercentage': minPercentVisible,
-                        'mtm.elementVisibilityId': dom.getElementAttribute(entry.target, 'id'),
-                        'mtm.elementVisibilityClasses': dom.getElementClassNames(entry.target),
-                        'mtm.elementVisibilityText': TagManager.utils.trim(entry.target.innerText),
-                        'mtm.elementVisibilityNodeName': entry.target.nodeName,
-                        'mtm.elementVisibilityUrl': entry.target.href || dom.getElementAttribute(entry.target, 'href'),
-                    });
+        /************************************************************
+         * Element Visiblility
+         ************************************************************/
 
-                    if (fireTriggerWhen === 'oncePage') {
-                        TagManager.dom.bySelector(selectors).forEach(function (element) {
-                            observer.unobserve(element);
-                            triggeredNodes.push(element);
-                        });
-                    } else if(onlyOncePerElement) {
-                        observer.unobserve(entry.target);
-                        triggeredNodes.push(entry.target); // to avoid possible memory leaks as much as possible we add onceElement only when needed
+        /**
+         * Author: Jason Farrell
+         * Author URI: http://useallfive.com/
+         *
+         * Description: Checks if a DOM element is truly visible.
+         * Package URL: https://github.com/UseAllFive/true-visibility
+         * License: MIT (https://github.com/UseAllFive/true-visibility/blob/master/LICENSE.txt)
+         */
+        function isVisible(node) {
+
+            if (!node) {
+                return false;
+            }
+
+            //-- Cross browser method to get style properties:
+            function _getStyle(el, property) {
+                if (windowAlias.getComputedStyle) {
+                    return documentAlias.defaultView.getComputedStyle(el,null)[property];
+                }
+                if (el.currentStyle) {
+                    return el.currentStyle[property];
+                }
+            }
+
+            function _elementInDocument(element) {
+                element = element.parentNode;
+
+                while (element) {
+                    if (element === documentAlias) {
+                        return true;
+                    }
+                    element = element.parentNode;
+                }
+                return false;
+            }
+
+            /**
+             * Checks if a DOM element is visible. Takes into
+             * consideration its parents and overflow.
+             *
+             * @param (el)      the DOM element to check if is visible
+             *
+             * These params are optional that are sent in recursively,
+             * you typically won't use these:
+             *
+             * @param (t)       Top corner position number
+             * @param (r)       Right corner position number
+             * @param (b)       Bottom corner position number
+             * @param (l)       Left corner position number
+             * @param (w)       Element width number
+             * @param (h)       Element height number
+             */
+            function _isVisible(el, t, r, b, l, w, h) {
+                var p = el.parentNode,
+                    VISIBLE_PADDING = 1; // has to be visible at least one px of the element
+
+                if (!_elementInDocument(el)) {
+                    return false;
+                }
+
+                //-- Return true for document node
+                if (9 === p.nodeType) {
+                    return true;
+                }
+
+                //-- Return false if our element is invisible
+                if (
+                    '0' === _getStyle(el, 'opacity') ||
+                    'none' === _getStyle(el, 'display') ||
+                    'hidden' === _getStyle(el, 'visibility')
+                ) {
+                    return false;
+                }
+
+                if (!utils.isDefined(t) ||
+                    !utils.isDefined(r) ||
+                    !utils.isDefined(b) ||
+                    !utils.isDefined(l) ||
+                    !utils.isDefined(w) ||
+                    !utils.isDefined(h)) {
+                    t = el.offsetTop;
+                    l = el.offsetLeft;
+                    b = t + el.offsetHeight;
+                    r = l + el.offsetWidth;
+                    w = el.offsetWidth;
+                    h = el.offsetHeight;
+                }
+
+                if (node === el && (0 === h || 0 === w) && 'hidden' === _getStyle(el, 'overflow')) {
+                    return false;
+                }
+
+                //-- If we have a parent, let's continue:
+                if (p) {
+                    //-- Check if the parent can hide its children.
+                    if (('hidden' === _getStyle(p, 'overflow') || 'scroll' === _getStyle(p, 'overflow'))) {
+                        //-- Only check if the offset is different for the parent
+                        if (
+                            //-- If the target element is to the right of the parent elm
+                            l + VISIBLE_PADDING > p.offsetWidth + p.scrollLeft ||
+                            //-- If the target element is to the left of the parent elm
+                            l + w - VISIBLE_PADDING < p.scrollLeft ||
+                            //-- If the target element is under the parent elm
+                            t + VISIBLE_PADDING > p.offsetHeight + p.scrollTop ||
+                            //-- If the target element is above the parent elm
+                            t + h - VISIBLE_PADDING < p.scrollTop
+                        ) {
+                            //-- Our target element is out of bounds:
+                            return false;
+                        }
+                    }
+                    //-- Add the offset parent's left/top coords to our element's offset:
+                    if (el.offsetParent === p) {
+                        l += p.offsetLeft;
+                        t += p.offsetTop;
+                    }
+                    //-- Let's recursively check upwards:
+                    return _isVisible(p, t, r, b, l, w, h);
+                }
+                return true;
+            }
+
+            return _isVisible(node);
+        }
+
+        function checkVisiblity (triggerEvent) {
+            return function (event) {
+                if (blockTrigger) {
+                    // oncePerPage trigger only. do not trigger it again
+                    return;
+                }
+                var nodes = [];
+                var selectionMethod = parameters.get('selectionMethod');
+
+                var dom = TagManager.dom;
+
+                if (selectionMethod === 'elementId') {
+                    var node = dom.byId(parameters.get('elementId'));
+                    if (node) {
+                        nodes.push(node);
+                    }
+                } else if (selectionMethod === 'cssSelector') {
+                    nodes = dom.bySelector(parameters.get('cssSelector'));
+                } else {
+                    return;
+                }
+
+                for (var i = 0; i < nodes.length; i++) {
+                    if (onlyOncePerElement) {
+                        if (isNodeEventTriggered(nodes[i])) {
+                            continue;
+                        }
+                    }
+                    if (nodes[i] && isVisible(nodes[i])) {
+                        var percentVisible = getPercentVisible(nodes[i]);
+                        if (!minPercentVisible || minPercentVisible <= percentVisible) {
+                            triggerEvent({
+                                event: 'mtm.ElementVisibility',
+                                'mtm.elementVisibilityPercentage': Math.round(percentVisible * 100) / 100,
+                                'mtm.elementVisibilityId': dom.getElementAttribute(nodes[i], 'id'),
+                                'mtm.elementVisibilityClasses': dom.getElementClassNames(nodes[i]),
+                                'mtm.elementVisibilityText': TagManager.utils.trim(nodes[i].innerText),
+                                'mtm.elementVisibilityNodeName': nodes[i].nodeName,
+                                'mtm.elementVisibilityUrl': nodes[i].href || dom.getElementAttribute(nodes[i], 'href'),
+                            });
+                            if (fireTriggerWhen === 'oncePage') {
+                                blockTrigger = true;
+                                TagManager.window.offScroll(self.scrollIndex);
+                            } else if (onlyOncePerElement) {
+                                triggeredNodes.push(nodes[i]); // to avoid possible memory leaks as much as possible we add onceElement only when needed
+                            }
+                        }
                     }
                 }
-            });
+            };
         }
 
         function getSelectors() {
@@ -70,7 +241,70 @@
             return;
         }
 
+        function setIntersectionObserver(triggerEvent) {
+            if ('IntersectionObserver' in window) {
+                var interSectionObserverOptions = {
+                    root: null, // document's viewport as the container.
+                    rootMargin: '0px',
+                    threshold: (minPercentVisible / 100)
+                };
+                var observerIntersection = new IntersectionObserver(function (entries) {
+                    interSectionCallback(entries, triggerEvent, observerIntersection);
+                }, interSectionObserverOptions);
+
+                if (selectors) {
+                    TagManager.dom.bySelector(selectors).forEach(function (element) {
+                        observerIntersection.observe(element);
+                    });
+                }
+            }
+
+        }
+
+        function interSectionCallback(entries, triggerEvent, observer) {
+            var dom = TagManager.dom;
+            entries.forEach(function (entry) {
+                if (entry.intersectionRatio > 0) {
+                    if (blockTrigger || (onlyOncePerElement && isNodeEventTriggered(entry.target))) {
+                        return;
+                    }
+                    triggerEvent({
+                        event: 'mtm.ElementVisibility',
+                        'mtm.elementVisibilityPercentage': minPercentVisible,
+                        'mtm.elementVisibilityId': dom.getElementAttribute(entry.target, 'id'),
+                        'mtm.elementVisibilityClasses': dom.getElementClassNames(entry.target),
+                        'mtm.elementVisibilityText': TagManager.utils.trim(entry.target.innerText),
+                        'mtm.elementVisibilityNodeName': entry.target.nodeName,
+                        'mtm.elementVisibilityUrl': entry.target.href || dom.getElementAttribute(entry.target, 'href'),
+                    });
+
+                    if (fireTriggerWhen === 'oncePage') {
+                        blockTrigger = true;
+                        TagManager.dom.bySelector(selectors).forEach(function (element) {
+                            observer.unobserve(element);
+                            triggeredNodes.push(element);
+                        });
+                    } else if(onlyOncePerElement) {
+                        observer.unobserve(entry.target);
+                        triggeredNodes.push(entry.target); // to avoid possible memory leaks as much as possible we add onceElement only when needed
+                    }
+                }
+            });
+        }
+
+        function isNodeEventTriggered(node) {
+            for (var j = 0; j < triggeredNodes.length; j++) {
+                if (node === triggeredNodes[j]) {
+                    return true;
+                }
+            }
+
+            return false;
+        }
+
         this.setUp = function (triggerEvent) {
+            this.scrollIndex = TagManager.window.onScroll(checkVisiblity(triggerEvent));
+            TagManager.dom.onLoad(checkVisiblity(triggerEvent));
             setIntersectionObserver(triggerEvent);
         };
     };

--- a/tests/javascript/index.php
+++ b/tests/javascript/index.php
@@ -2303,7 +2303,7 @@
                     "mtm.elementVisibilityClasses": "",
                     "mtm.elementVisibilityId": "qunit-header",
                     "mtm.elementVisibilityNodeName": 'H1',
-                    "mtm.elementVisibilityPercentage": 79.17,
+                    "mtm.elementVisibilityPercentage": 10
                     "mtm.elementVisibilityText": "piwik.js: Unit Tests",
                     "mtm.elementVisibilityUrl": null
                 }], events, 'should have triggered visibility event');

--- a/tests/javascript/index.php
+++ b/tests/javascript/index.php
@@ -2303,7 +2303,7 @@
                     "mtm.elementVisibilityClasses": "",
                     "mtm.elementVisibilityId": "qunit-header",
                     "mtm.elementVisibilityNodeName": 'H1',
-                    "mtm.elementVisibilityPercentage": 10
+                    "mtm.elementVisibilityPercentage": 79.17,
                     "mtm.elementVisibilityText": "piwik.js: Unit Tests",
                     "mtm.elementVisibilityUrl": null
                 }], events, 'should have triggered visibility event');


### PR DESCRIPTION
Implemented Intersection Observer to fire visibility trigger along with scroll and DOM load

### Description:

The code will now also use Intersection Observer to detect visibility
This will help us to track elements which gets visible when there is no scroll event.
It will automatically stop observing if trigger once per page or once per element is set.
This will fix the issue #328 

### Review

* [ ] [Functional review done](https://developer.matomo.org/guides/pull-request-reviews#functional-review-done)
* [ ] [Potential edge cases thought about](https://developer.matomo.org/guides/pull-request-reviews#potential-edge-cases-thought-about) (behavior of the code with strange input, with strange internal state or possible interactions with other Matomo subsystems)
* [ ] [Usability review done](https://developer.matomo.org/guides/pull-request-reviews#usability-review-done) (is anything maybe unclear or think about anything that would cause people to reach out to support)
* [ ] [Security review done](https://developer.matomo.org/guides/security-in-piwik#checklist)
* [ ] [Wording review done](https://developer.matomo.org/guides/pull-request-reviews#translations-wording-review-done)
* [ ] [Code review done](https://developer.matomo.org/guides/pull-request-reviews#code-review-done)
* [ ] [Tests were added if useful/possible](https://developer.matomo.org/guides/pull-request-reviews#tests-were-added-if-usefulpossible)
* [ ] [Reviewed for breaking changes](https://developer.matomo.org/guides/pull-request-reviews#reviewed-for-breaking-changes)
* [ ] [Developer changelog updated if needed](https://developer.matomo.org/guides/pull-request-reviews#developer-changelog-updated-if-needed)
* [ ] [Documentation added if needed](https://developer.matomo.org/guides/pull-request-reviews#documentation-added-if-needed)
* [ ] Existing documentation updated if needed
