### PR TITLE
Ensure window unload is triggered only once

### DIFF
--- a/Template/Trigger/WindowUnloadTrigger.web.js
+++ b/Template/Trigger/WindowUnloadTrigger.web.js
@@ -1,7 +1,12 @@
 (function () {
     return function (parameters, TagManager) {
         this.setUp = function (triggerEvent) {
+            var triggered = false;
             TagManager.dom.addEventListener(parameters.window, 'beforeunload', function () {
+                if (triggered) {
+                    return;
+                }
+                triggered = true;
                 triggerEvent({event: 'WindowUnload'});
             });
         };


### PR DESCRIPTION
### Description:

fix https://github.com/matomo-org/tag-manager/issues/349

Not sure why it would have been triggered multiple times in edge but this will make sure it won't.

### Review

* [ ] [Functional review done](https://developer.matomo.org/guides/pull-request-reviews#functional-review-done)
* [ ] [Potential edge cases thought about](https://developer.matomo.org/guides/pull-request-reviews#potential-edge-cases-thought-about) (behavior of the code with strange input, with strange internal state or possible interactions with other Matomo subsystems)
* [ ] [Usability review done](https://developer.matomo.org/guides/pull-request-reviews#usability-review-done) (is anything maybe unclear or think about anything that would cause people to reach out to support)
* [ ] [Security review done](https://developer.matomo.org/guides/security-in-piwik#checklist)
* [ ] [Wording review done](https://developer.matomo.org/guides/pull-request-reviews#translations-wording-review-done)
* [ ] [Code review done](https://developer.matomo.org/guides/pull-request-reviews#code-review-done)
* [ ] [Tests were added if useful/possible](https://developer.matomo.org/guides/pull-request-reviews#tests-were-added-if-usefulpossible)
* [ ] [Reviewed for breaking changes](https://developer.matomo.org/guides/pull-request-reviews#reviewed-for-breaking-changes)
* [ ] [Developer changelog updated if needed](https://developer.matomo.org/guides/pull-request-reviews#developer-changelog-updated-if-needed)
* [ ] [Documentation added if needed](https://developer.matomo.org/guides/pull-request-reviews#documentation-added-if-needed)
* [ ] Existing documentation updated if needed
