### PR TITLE
Fix deprecation warning on PHP 8.1

### DIFF
--- a/Context/WebContext/JavaScriptTagManagerLoader.php
+++ b/Context/WebContext/JavaScriptTagManagerLoader.php
@@ -70,7 +70,7 @@ class JavaScriptTagManagerLoader
             $debugContent = FrontController::getInstance()->dispatch('TagManager', 'debug');
         });
 
-        $debugContent = str_replace(Piwik::getCurrentUserTokenAuth(), 'anonymous', $debugContent); // make sure to not expose somehow the token
+        $debugContent = str_replace(Piwik::getCurrentUserTokenAuth() ?? '', 'anonymous', $debugContent); // make sure to not expose somehow the token
         $debugContent = json_encode($debugContent);
         $previewJs = str_replace(array('/*!! previewContent */', '/*!!! previewContent */'), $debugContent, $previewJs);
 


### PR DESCRIPTION
### Description:

```
WARNING [2021-11-14 21:41:56] 24835  /srv/matomo/plugins/TagManager/Context/WebContext/JavaScriptTagManagerLoader.php(73): Deprecated - str_replace(): Passing null to parameter #1 ($search) of type array|string is deprecated - Matomo 4.6.0-b4 - Please report this message in the Matomo forums: https://forum.matomo.org (please do a search first as it might have been reported already)
```

Happened while deactivating a plugin via console. The token_auth is null in that case

### Review

* [ ] [Functional review done](https://developer.matomo.org/guides/pull-request-reviews#functional-review-done)
* [ ] [Potential edge cases thought about](https://developer.matomo.org/guides/pull-request-reviews#potential-edge-cases-thought-about) (behavior of the code with strange input, with strange internal state or possible interactions with other Matomo subsystems)
* [ ] [Usability review done](https://developer.matomo.org/guides/pull-request-reviews#usability-review-done) (is anything maybe unclear or think about anything that would cause people to reach out to support)
* [ ] [Security review done](https://developer.matomo.org/guides/security-in-piwik#checklist)
* [ ] [Wording review done](https://developer.matomo.org/guides/pull-request-reviews#translations-wording-review-done)
* [ ] [Code review done](https://developer.matomo.org/guides/pull-request-reviews#code-review-done)
* [ ] [Tests were added if useful/possible](https://developer.matomo.org/guides/pull-request-reviews#tests-were-added-if-usefulpossible)
* [ ] [Reviewed for breaking changes](https://developer.matomo.org/guides/pull-request-reviews#reviewed-for-breaking-changes)
* [ ] [Developer changelog updated if needed](https://developer.matomo.org/guides/pull-request-reviews#developer-changelog-updated-if-needed)
* [ ] [Documentation added if needed](https://developer.matomo.org/guides/pull-request-reviews#documentation-added-if-needed)
* [ ] Existing documentation updated if needed
