### PR TITLE
Ensure console commands return integers

### DIFF
--- a/Commands/GenerateDataLayerVariable.php
+++ b/Commands/GenerateDataLayerVariable.php
@@ -56,6 +56,8 @@ class GenerateDataLayerVariable extends GeneratePluginBase
             'You can now start implementing the preconfigured data layer variable',
             'Enjoy!'
         ));
+
+        return 0;
     }
 
     /**

--- a/Commands/GeneratePreconfiguredVariable.php
+++ b/Commands/GeneratePreconfiguredVariable.php
@@ -56,6 +56,8 @@ class GeneratePreconfiguredVariable extends GeneratePluginBase
             'You can now start implementing the preconfigured variable',
             'Enjoy!'
         ));
+
+        return 0;
     }
 
     /**

--- a/Commands/GenerateTag.php
+++ b/Commands/GenerateTag.php
@@ -58,6 +58,8 @@ class GenerateTag extends GeneratePluginBase
             'You can now start implementing the tag',
             'Enjoy!'
         ));
+
+        return 0;
     }
 
     /**

--- a/Commands/GenerateTrigger.php
+++ b/Commands/GenerateTrigger.php
@@ -58,6 +58,8 @@ class GenerateTrigger extends GeneratePluginBase
             'You can now start implementing the trigger',
             'Enjoy!'
         ));
+
+        return 0;
     }
 
     /**

--- a/Commands/GenerateVariable.php
+++ b/Commands/GenerateVariable.php
@@ -57,6 +57,8 @@ class GenerateVariable extends GeneratePluginBase
             'You can now start implementing the variable',
             'Enjoy!'
         ));
+
+        return 0;
     }
 
     /**

--- a/Commands/RegenerateContainers.php
+++ b/Commands/RegenerateContainers.php
@@ -26,5 +26,7 @@ class RegenerateContainers extends ConsoleCommand
         Piwik::postEvent('TagManager.regenerateContainerReleases');
 
         $output->writeln('<info>Done</info>');
+
+        return 0;
     }
 }


### PR DESCRIPTION
### Description:

Newer versions of symfony console will throw an error when a console command does not return an integer.

### Review

* [ ] [Functional review done](https://developer.matomo.org/guides/pull-request-reviews#functional-review-done)
* [ ] [Potential edge cases thought about](https://developer.matomo.org/guides/pull-request-reviews#potential-edge-cases-thought-about) (behavior of the code with strange input, with strange internal state or possible interactions with other Matomo subsystems)
* [ ] [Usability review done](https://developer.matomo.org/guides/pull-request-reviews#usability-review-done) (is anything maybe unclear or think about anything that would cause people to reach out to support)
* [ ] [Security review done](https://developer.matomo.org/guides/security-in-piwik#checklist)
* [ ] [Wording review done](https://developer.matomo.org/guides/pull-request-reviews#translations-wording-review-done)
* [ ] [Code review done](https://developer.matomo.org/guides/pull-request-reviews#code-review-done)
* [ ] [Tests were added if useful/possible](https://developer.matomo.org/guides/pull-request-reviews#tests-were-added-if-usefulpossible)
* [ ] [Reviewed for breaking changes](https://developer.matomo.org/guides/pull-request-reviews#reviewed-for-breaking-changes)
* [ ] [Developer changelog updated if needed](https://developer.matomo.org/guides/pull-request-reviews#developer-changelog-updated-if-needed)
* [ ] [Documentation added if needed](https://developer.matomo.org/guides/pull-request-reviews#documentation-added-if-needed)
* [ ] Existing documentation updated if needed
