### PR TITLE
Make import and publish version faster when there are many tags/triggers

### DIFF
--- a/API.php
+++ b/API.php
@@ -122,6 +122,8 @@ class API extends \Piwik\Plugin\API
      */
     private $variablesDao;
 
+    private $enableGeneratePreview = true;
+
     public function __construct(Tag $tags, Trigger $triggers, Variable $variables, Container $containers, TagsProvider $tagsProvider, TriggersProvider $triggersProvider, VariablesProvider $variablesProvider, ContextProvider $contextProvider, AccessValidator $validator, Environment $environment, Comparison $comparisons, Export $export, Import $import, VariablesDao $variablesDao)
     {
         $this->tags = $tags;
@@ -1284,11 +1286,17 @@ class API extends \Piwik\Plugin\API
         }
 
         $this->containers->checkContainerVersionExists($idSite, $idContainer, $idContainerVersion);
+        $this->enableGeneratePreview = false;
         $this->import->importContainerVersion($exportedContainerVersion, $idSite, $idContainer, $idContainerVersion);
+        $this->enableGeneratePreview = true;
+        $this->updateContainerPreviewRelease($idSite, $idContainer);
     }
 
     private function updateContainerPreviewRelease($idSite, $idContainer)
     {
+        if (!$this->enableGeneratePreview) {
+            return;
+        }
         if ($this->containers->hasPreviewRelease($idSite, $idContainer)) {
             $this->containers->generateContainer($idSite, $idContainer);
         } else {

--- a/API.php
+++ b/API.php
@@ -1012,7 +1012,12 @@ class API extends \Piwik\Plugin\API
             $idContainerVersion = $this->getContainerDraftVersion($idSite, $idContainer);
         }
 
-        return $this->containers->createContainerVersion($idSite, $idContainer, $idContainerVersion, $name, $description);
+        $this->enableGeneratePreview = false;
+        $container = $this->containers->createContainerVersion($idSite, $idContainer, $idContainerVersion, $name, $description);
+        // not needed to create a preview release as no actual change to container was made. Make it faster as the createContainerVersion
+        // uses "import" logic which would create a new preview release or check for recursions on every created tag/trigger/...
+        $this->enableGeneratePreview = true;
+        return $container;
     }
 
     /**


### PR DESCRIPTION
### Description:

* Go to versions
* Click on Import
* Import the data of https://pastebin.com/R5J6XEWN which includes > 200 tags and > 200 triggers.
* This will take a very long time previously and might not complete in many minutes. With this fix it took < 1s.
* Then once imported, try to publish a new release and it will be as slow. With this fix it should be fast again.

For every tag/trigger/... it will try to either update the preview JS file, or check if there are any recursions in there.

This changes it to only check for recursions at the end which is a lot faster. From > 100 seconds it goes down to < 1s.

However, when we notice there are recursions, then it may be too late as the data is already imported. I haven't tested it but believe the user would be still made aware of this though with an error message.

@AltamashShaikh putting this in the current sprint so maybe you can confirm this works now faster. I also quickly checked what happens when a variable references itself (see https://github.com/matomo-org/tag-manager/pull/293). 

> Eg create a MatomoConfiguration variable named "Matomo Configuration" and set Matomo URL to "https://matomo.org{{Matomo Configuration}}".

I guess we could argue that now it shouldn't be possible to create anymore any variables that reference itself, so it also won't happen that you import such variables anymore so it's not an issue. Unless someone created this JSON themselves. Be edge case though and the performance benefit be a lot quicker. 

What happened in above case was that the import actually didn't work anyway with below JSON where it references itself as it complained it couldn't delete a variable.... Below an import with a variable where it references itself:

```
{"idcontainer":"lRjDHEmG","idsite":1,"context":"web","name":"test2","description":"","created_date":"2021-12-09 19:28:11","updated_date":"2021-12-09 19:28:11","created_date_pretty":"Dec 9, 2021 20:28:11","updated_date_pretty":"Dec 9, 2021 20:28:11","revision":0,"version":{"name":"","description":"","revision":0,"created_date":"2021-12-09 19:28:11","created_date_pretty":"Dec 9, 2021 20:28:11","updated_date":"2021-12-09 19:28:11","updated_date_pretty":"Dec 9, 2021 20:28:11"},"tags":[],"triggers":[],"variables":[{"idvariable":36,"type":"MatomoConfiguration","name":"Matomo Configuration","parameters":{"matomoUrl":"{{Matomo Configuration}}","idSite":"1","enableLinkTracking":true,"enableCrossDomainLinking":false,"enableDoNotTrack":false,"enableJSErrorTracking":false,"enableHeartBeatTimer":false,"trackAllContentImpressions":false,"trackVisibleContentImpressions":false,"disableCookies":false,"requireConsent":false,"requireCookieConsent":false,"setSecureCookie":false,"cookieDomain":"","cookiePath":"","cookieSameSite":"Lax","domains":[],"alwaysUseSendBeacon":false,"userId":"","customDimensions":[],"bundleTracker":true,"registerAsDefaultTracker":true,"jsEndpoint":"matomo.js","trackingEndpoint":"matomo.php"},"lookup_table":[],"default_value":"","created_date":"2021-12-09 19:28:53","updated_date":"2021-12-09 19:28:53","created_date_pretty":"Dec 9, 2021 20:28:53","updated_date_pretty":"Dec 9, 2021 20:28:53"}]}
```

@AltamashShaikh what

### Review

* [ ] [Functional review done](https://developer.matomo.org/guides/pull-request-reviews#functional-review-done)
* [ ] [Potential edge cases thought about](https://developer.matomo.org/guides/pull-request-reviews#potential-edge-cases-thought-about) (behavior of the code with strange input, with strange internal state or possible interactions with other Matomo subsystems)
* [ ] [Usability review done](https://developer.matomo.org/guides/pull-request-reviews#usability-review-done) (is anything maybe unclear or think about anything that would cause people to reach out to support)
* [ ] [Security review done](https://developer.matomo.org/guides/security-in-piwik#checklist)
* [ ] [Wording review done](https://developer.matomo.org/guides/pull-request-reviews#translations-wording-review-done)
* [ ] [Code review done](https://developer.matomo.org/guides/pull-request-reviews#code-review-done)
* [ ] [Tests were added if useful/possible](https://developer.matomo.org/guides/pull-request-reviews#tests-were-added-if-usefulpossible)
* [ ] [Reviewed for breaking changes](https://developer.matomo.org/guides/pull-request-reviews#reviewed-for-breaking-changes)
* [ ] [Developer changelog updated if needed](https://developer.matomo.org/guides/pull-request-reviews#developer-changelog-updated-if-needed)
* [ ] [Documentation added if needed](https://developer.matomo.org/guides/pull-request-reviews#documentation-added-if-needed)
* [ ] Existing documentation updated if needed
