### PR TITLE
Added option to filter only fired tags with indicator

### DIFF
--- a/LEGALNOTICE
+++ b/LEGALNOTICE
@@ -50,7 +50,7 @@ SEPARATELY LICENSED COMPONENTS AND LIBRARIES
 	Link: https://github.com/FortAwesome/Font-Awesome/
 	License: CC BY 4.0 License (https://creativecommons.org/licenses/by/4.0/)
 
-	Name: IcoMoon - Free icons ("/images/icons/form.svg", "/images/icons/image.svg")
+	Name: IcoMoon - Free icons ("/images/icons/form.svg", "/images/icons/image.svg", "/templates/debug.twig/icon-checkmark")
 	Link: https://icomoon.io/#icons-icomoon
 	License: GPL
 

--- a/templates/debug.twig
+++ b/templates/debug.twig
@@ -16,16 +16,18 @@
             margin-top: 0;
         }
 
-        .tm-icon-ok {
-            position: absolute;
-            background-repeat: no-repeat;
+        .tm-icon {
             display: inline-block;
-            background-size: cover;
-            margin-left: 0.5rem;
-            margin-top: 2px;
-            background-image: url("data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAADAAAAAwCAYAAABXAvmHAAAABmJLR0QA/wD/AP+gvaeTAAAEDUlEQVRoge2XXWxURRTH/+fe/ShBioFo8NvaNmrLhyI2kDal22px0cVEWZSYQtHSIIREn4wmhkXro9EHI6EIaVIjUoS2VEqtJG7j1oJiGi3EwpYtiFEUEyAL2u7eO8cHRe323r2zH3Ebc3/JvMz8z/+ck72zMwPY2NjY2NjY5A7KdQFGrD/rKwXoTRZ8UkP0pZaC4JiZdso10HDGV0BAP4Cb/po6Qi74mm/u+tVIr/x3pVmzLuy9QQEO4Z/iAWAxx9DXeNp3u1HMlGlgc9ib73A6ehi422C5BA6E/vy0JjIlGtgc9rrHnI52AAvNNMy4DYwu8MTPPucNBDigjDkdrQCqrbQMTEucy3kDP5z9+h0AfglpjEipA4H/PZnTBhpHVwQIeF5CKph5zY47Og8nLuTsb3T96GMbGNgmp+YX3ys4+LbRimUDG09UXRed7eLWOb1XUyvRnIaIdyWDPgSgSsibdt7V/arZYtIG1o3UVoPoABg6g9e2FPV2pFqsoSeoG4DbSkvAjl1FnzQm05jugbrh2gIheI/QxXQhRD4L3l9/sjaQRs1/s2a4Zr4QvE8I4RZCwGIciJwb32jlafgLPDtcPkNT3F+AMTdxjUHN537UNwU9QS2V4teGqwtZIARgjqWY0ae4xSPJ7kDXmNRAgAPKyPBn7QCtSBLX46L4ql339EctiwFQN1J7I8djIQDFEvIhEdeWfjA/dFHGe1IDq4+XvwDQW9aB9BVzzLd73tGfk+n8xx6a6cgb6wOwQKKeiKpQxfsln/8koQVgsAdYaPOE0GA1dBF/UDAdeWpo8b1m5vWjVXmq60qnENoCaz/tF430ZakUb9gAdHpd0/XTutAhMe7Udb1/5eCiqkQbf5tfvXr5ym5N6EslfKIax717SwdGUikeMNnE/hOls/RxVzuASkmfGICG/QsHWwEADHpi8P5mAA0ysYoifB/d902vZK4JmJ4D3nCR23V52k4wnpH0YgK91rHo262PH5vbBNArEjGCmFd3lB1vk8wxieQnMYN8X5Y0AZAp5prlAMBL5KS8qavsu3flvQ0sZETLB4rrAdoOwJVJsgS2di85ldHBCKRwmfP2F1YL5n0EXJ9pUgDbeyoiG7Lgk9pt9OG+W4tBjoMAyxxIJgm5c+b575/cuwp6uh4T/VKk5vAts4WKDgIqUo1lIMhweoOeM5ZXBFnSeg94u4vcv7ujLQCeTiFsCMp4ZdBz6VI6Oc1I/0HDoMreWVuYsEVCHVGdannQc+F82vlMyPhFVn5oxnMM2gbAaSK5oAiuCD0aPZVpLiOy8qQs+3j6MgK3AchPWLqoKKgZWP7bYDbyGJG1N/ED7e5CUvkNYvYwKA+MT1WVXj7qGw9nK4eNjY2Njc3/jj8AuzXhYrmOV6EAAAAASUVORK5CYII=");
-            height: 16px;
-            width: 16px;
+            color: #444444;
+            width: 1em;
+            height: 1em;
+            fill: currentColor;
+        }
+
+        .tm-icon-checkmark {
+            color: green;
+            position: relative;
+            top: 2px;
         }
 
         .lbl-onlyfiredTags {
@@ -92,6 +94,14 @@
             </div>
         </nav>
 
+        <svg aria-hidden="true" style="position: absolute; width: 0; height: 0; overflow: hidden;" version="1.1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+            <defs>
+                <symbol id="tm-icon-checkmark" viewBox="0 0 32 32">
+                    <path d="M27 4l-15 15-7-7-5 5 12 12 20-20z"></path>
+                </symbol>
+            </defs>
+        </svg>
+
         <div class="page" style="clear:both;">
             <div id="secondNavBar" class="Menu--dashboard z-depth-1"
                  ng-show="mtmDebug.contentTab != 'logs'">
@@ -109,7 +119,9 @@
                     <li class="menuTab" role="menuitem" ng-class="{'active': eventIndex === mtmDebug.selectedEventIndex}"
                     ng-repeat="event in mtmDebug.mtmEvents | orderBy:'$index':true" ng-hide="!event.tags.length && onlyfiredTags">
                         <a class="item ng-binding"  ng-click="mtmDebug.selectEvent(event.index0)" title="Time: {{ '{{ event.time }}'|raw }}. Trigger: '{{ '{{ event.metTrigger.name }}'|raw }}'">
-                            {{ '{{ event.index }}'|raw }}: {{ '{{ event.name }}'|raw }} <span title="Events with fired tags" class="{{ '{{ event.tags.length ? \'tm-icon-ok\' : \'\' }}' }}"></span>
+                            {{ '{{ event.index }}'|raw }}: {{ '{{ event.name }}'|raw }} <span title="Events with fired tags" ng-show="event.tags.length">
+                                 <svg class="tm-icon tm-icon-checkmark"><use xlink:href="#tm-icon-checkmark"></use></svg>
+                            </span>
                         </a>
                     </li>
                 </ul>

--- a/templates/debug.twig
+++ b/templates/debug.twig
@@ -119,7 +119,7 @@
                     <li class="menuTab" role="menuitem" ng-class="{'active': eventIndex === mtmDebug.selectedEventIndex}"
                     ng-repeat="event in mtmDebug.mtmEvents | orderBy:'$index':true" ng-hide="!event.tags.length && onlyfiredTags">
                         <a class="item ng-binding"  ng-click="mtmDebug.selectEvent(event.index0)" title="Time: {{ '{{ event.time }}'|raw }}. Trigger: '{{ '{{ event.metTrigger.name }}'|raw }}'">
-                            {{ '{{ event.index }}'|raw }}: {{ '{{ event.name }}'|raw }} <span title="Events with fired tags" ng-show="event.tags.length">
+                            {{ '{{ event.index }}'|raw }}: {{ '{{ event.name }}'|raw }} <span title="This tag was fired" ng-show="event.tags.length">
                                  <svg class="tm-icon tm-icon-checkmark"><use xlink:href="#tm-icon-checkmark"></use></svg>
                             </span>
                         </a>

--- a/templates/debug.twig
+++ b/templates/debug.twig
@@ -16,16 +16,20 @@
             margin-top: 0;
         }
 
-        .icon-ok {
-            color: green;
-            top: 2px;
-            position: relative;
+        .tm-icon-ok {
+            position: absolute;
+            background-repeat: no-repeat;
+            display: inline-block;
+            background-size: cover;
+            margin-left: 0.5rem;
+            margin-top: 2px;
+            background-image: url("data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAADAAAAAwCAYAAABXAvmHAAAABmJLR0QA/wD/AP+gvaeTAAAEDUlEQVRoge2XXWxURRTH/+fe/ShBioFo8NvaNmrLhyI2kDal22px0cVEWZSYQtHSIIREn4wmhkXro9EHI6EIaVIjUoS2VEqtJG7j1oJiGi3EwpYtiFEUEyAL2u7eO8cHRe323r2zH3Ebc3/JvMz8z/+ck72zMwPY2NjY2NjY5A7KdQFGrD/rKwXoTRZ8UkP0pZaC4JiZdso10HDGV0BAP4Cb/po6Qi74mm/u+tVIr/x3pVmzLuy9QQEO4Z/iAWAxx9DXeNp3u1HMlGlgc9ib73A6ehi422C5BA6E/vy0JjIlGtgc9rrHnI52AAvNNMy4DYwu8MTPPucNBDigjDkdrQCqrbQMTEucy3kDP5z9+h0AfglpjEipA4H/PZnTBhpHVwQIeF5CKph5zY47Og8nLuTsb3T96GMbGNgmp+YX3ys4+LbRimUDG09UXRed7eLWOb1XUyvRnIaIdyWDPgSgSsibdt7V/arZYtIG1o3UVoPoABg6g9e2FPV2pFqsoSeoG4DbSkvAjl1FnzQm05jugbrh2gIheI/QxXQhRD4L3l9/sjaQRs1/s2a4Zr4QvE8I4RZCwGIciJwb32jlafgLPDtcPkNT3F+AMTdxjUHN537UNwU9QS2V4teGqwtZIARgjqWY0ae4xSPJ7kDXmNRAgAPKyPBn7QCtSBLX46L4ql339EctiwFQN1J7I8djIQDFEvIhEdeWfjA/dFHGe1IDq4+XvwDQW9aB9BVzzLd73tGfk+n8xx6a6cgb6wOwQKKeiKpQxfsln/8koQVgsAdYaPOE0GA1dBF/UDAdeWpo8b1m5vWjVXmq60qnENoCaz/tF430ZakUb9gAdHpd0/XTutAhMe7Udb1/5eCiqkQbf5tfvXr5ym5N6EslfKIax717SwdGUikeMNnE/hOls/RxVzuASkmfGICG/QsHWwEADHpi8P5mAA0ysYoifB/d902vZK4JmJ4D3nCR23V52k4wnpH0YgK91rHo262PH5vbBNArEjGCmFd3lB1vk8wxieQnMYN8X5Y0AZAp5prlAMBL5KS8qavsu3flvQ0sZETLB4rrAdoOwJVJsgS2di85ldHBCKRwmfP2F1YL5n0EXJ9pUgDbeyoiG7Lgk9pt9OG+W4tBjoMAyxxIJgm5c+b575/cuwp6uh4T/VKk5vAts4WKDgIqUo1lIMhweoOeM5ZXBFnSeg94u4vcv7ujLQCeTiFsCMp4ZdBz6VI6Oc1I/0HDoMreWVuYsEVCHVGdannQc+F82vlMyPhFVn5oxnMM2gbAaSK5oAiuCD0aPZVpLiOy8qQs+3j6MgK3AchPWLqoKKgZWP7bYDbyGJG1N/ED7e5CUvkNYvYwKA+MT1WVXj7qGw9nK4eNjY2Njc3/jj8AuzXhYrmOV6EAAAAASUVORK5CYII=");
+            height: 16px;
+            width: 16px;
         }
 
-        .icon-error {
-            color: red;
-            top: 1px;
-            position: relative;
+        .lbl-onlyfiredTags {
+            color: black;
         }
 
         .onlyFiredTags-chk {
@@ -93,13 +97,19 @@
                  ng-show="mtmDebug.contentTab != 'logs'">
                 <ul class="navbar" role="menu" style="padding: 0;">
                     <li class="menuTab" role="menuitem">
-                        <span class="item" style="font-weight: normal;"> Events <br><br> <input type="checkbox" class="onlyFiredTags-chk" name="onlyfiredTags" value="1" ng-model="onlyfiredTags"> Only fired tags</span>
+                        <span class="item" style="font-weight: normal;"> Events
+                            <span ng-hide="(mtmDebug.mtmEvents|length) == 0">
+                                <br><br>
+                                <input type="checkbox" class="onlyFiredTags-chk" name="onlyfiredTags" id="onlyfiredTags" value="1" ng-model="onlyfiredTags">
+                                <label for="onlyfiredTags" class="lbl-onlyfiredTags">Only fired tags</label>
+                            </span>
+                        </span>
                     </li>
-                    <li ng-show="(mtmDebug.mtmEvents|length) == 0">No event executed</li>
+                    <li ng-show="(mtmDebug.mtmEvents|length) == 0" style="padding: 0 0 1rem 1.2rem;">No event executed</li>
                     <li class="menuTab" role="menuitem" ng-class="{'active': eventIndex === mtmDebug.selectedEventIndex}"
                     ng-repeat="event in mtmDebug.mtmEvents | orderBy:'$index':true" ng-hide="!event.tags.length && onlyfiredTags">
                         <a class="item ng-binding"  ng-click="mtmDebug.selectEvent(event.index0)" title="Time: {{ '{{ event.time }}'|raw }}. Trigger: '{{ '{{ event.metTrigger.name }}'|raw }}'">
-                            {{ '{{ event.index }}'|raw }}: {{ '{{ event.name }}'|raw }} <span class="{{ '{{ event.tags.length ? \'icon-ok\' : \'icon-error\' }}' }}"></span>
+                            {{ '{{ event.index }}'|raw }}: {{ '{{ event.name }}'|raw }} <span title="Events with fired tags" class="{{ '{{ event.tags.length ? \'tm-icon-ok\' : \'\' }}' }}"></span>
                         </a>
                     </li>
                 </ul>

--- a/templates/debug.twig
+++ b/templates/debug.twig
@@ -15,6 +15,25 @@
         .home h2, .home h3 {
             margin-top: 0;
         }
+
+        .icon-ok {
+            color: green;
+            top: 2px;
+            position: relative;
+        }
+
+        .icon-error {
+            color: red;
+            top: 1px;
+            position: relative;
+        }
+
+        .onlyFiredTags-chk {
+            position: relative !important;
+            opacity: 1 !important;
+            pointer-events: all !important;
+            top: 2px;
+        }
     </style>
     <script>
         var piwik_translations = {};
@@ -74,13 +93,13 @@
                  ng-show="mtmDebug.contentTab != 'logs'">
                 <ul class="navbar" role="menu" style="padding: 0;">
                     <li class="menuTab" role="menuitem">
-                        <span class="item" style="font-weight: normal;"> Events</span>
+                        <span class="item" style="font-weight: normal;"> Events <br><br> <input type="checkbox" class="onlyFiredTags-chk" name="onlyfiredTags" value="1" ng-model="onlyfiredTags"> Only fired tags</span>
                     </li>
                     <li ng-show="(mtmDebug.mtmEvents|length) == 0">No event executed</li>
                     <li class="menuTab" role="menuitem" ng-class="{'active': eventIndex === mtmDebug.selectedEventIndex}"
-                    ng-repeat="event in mtmDebug.mtmEvents | orderBy:'$index':true">
+                    ng-repeat="event in mtmDebug.mtmEvents | orderBy:'$index':true" ng-hide="!event.tags.length && onlyfiredTags">
                         <a class="item ng-binding"  ng-click="mtmDebug.selectEvent(event.index0)" title="Time: {{ '{{ event.time }}'|raw }}. Trigger: '{{ '{{ event.metTrigger.name }}'|raw }}'">
-                            {{ '{{ event.index }}'|raw }}: {{ '{{ event.name }}'|raw }}
+                            {{ '{{ event.index }}'|raw }}: {{ '{{ event.name }}'|raw }} <span class="{{ '{{ event.tags.length ? \'icon-ok\' : \'icon-error\' }}' }}"></span>
                         </a>
                     </li>
                 </ul>


### PR DESCRIPTION
### Description:

Added option to filter only fired tags with indicator in preview debug mode.
Fixes: #340 

### Review

* [ ] [Functional review done](https://developer.matomo.org/guides/pull-request-reviews#functional-review-done)
* [ ] [Potential edge cases thought about](https://developer.matomo.org/guides/pull-request-reviews#potential-edge-cases-thought-about) (behavior of the code with strange input, with strange internal state or possible interactions with other Matomo subsystems)
* [ ] [Usability review done](https://developer.matomo.org/guides/pull-request-reviews#usability-review-done) (is anything maybe unclear or think about anything that would cause people to reach out to support)
* [ ] [Security review done](https://developer.matomo.org/guides/security-in-piwik#checklist)
* [ ] [Wording review done](https://developer.matomo.org/guides/pull-request-reviews#translations-wording-review-done)
* [ ] [Code review done](https://developer.matomo.org/guides/pull-request-reviews#code-review-done)
* [ ] [Tests were added if useful/possible](https://developer.matomo.org/guides/pull-request-reviews#tests-were-added-if-usefulpossible)
* [ ] [Reviewed for breaking changes](https://developer.matomo.org/guides/pull-request-reviews#reviewed-for-breaking-changes)
* [ ] [Developer changelog updated if needed](https://developer.matomo.org/guides/pull-request-reviews#developer-changelog-updated-if-needed)
* [ ] [Documentation added if needed](https://developer.matomo.org/guides/pull-request-reviews#documentation-added-if-needed)
* [ ] Existing documentation updated if needed
