### PR TITLE
Changed color of new version without publishing btn to orange

### DIFF
--- a/TagManager.php
+++ b/TagManager.php
@@ -543,6 +543,7 @@ class TagManager extends \Piwik\Plugin
         $stylesheets[] = "plugins/TagManager/angularjs/selectVariableType/select-variable-type.directive.less";
         $stylesheets[] = "plugins/TagManager/angularjs/form-field/field-variable-template.less";
         $stylesheets[] = "plugins/TagManager/angularjs/containerSelector/container-selector.less";
+        $stylesheets[] = "plugins/TagManager/angularjs/manageVersion/manage.directive.less";
     }
 
     public function getJsFiles(&$jsFiles)

--- a/TagManager.php
+++ b/TagManager.php
@@ -543,7 +543,7 @@ class TagManager extends \Piwik\Plugin
         $stylesheets[] = "plugins/TagManager/angularjs/selectVariableType/select-variable-type.directive.less";
         $stylesheets[] = "plugins/TagManager/angularjs/form-field/field-variable-template.less";
         $stylesheets[] = "plugins/TagManager/angularjs/containerSelector/container-selector.less";
-        $stylesheets[] = "plugins/TagManager/angularjs/manageVersion/manage.directive.less";
+        $stylesheets[] = "plugins/TagManager/angularjs/manageVersion/edit.directive.less";
     }
 
     public function getJsFiles(&$jsFiles)

--- a/angularjs/manageVersion/edit.directive.html
+++ b/angularjs/manageVersion/edit.directive.html
@@ -36,7 +36,7 @@
             </div>
 
             <div piwik-save-button
-                 class="createButton"
+                 class="createButton no-publish"
                  onconfirm="editVersion.edit ? editVersion.updateVersion() : editVersion.createVersion()"
                  data-disabled="editVersion.model.isUpdating || !editVersion.isDirty"
                  value="{{ editVersion.edit ? ('CoreUpdater_UpdateTitle'|translate) : ('TagManager_CreateVersionWithoutPublishing'|translate) }}"

--- a/angularjs/manageVersion/edit.directive.less
+++ b/angularjs/manageVersion/edit.directive.less
@@ -1,4 +1,4 @@
-.createButton {
+.no-publish {
   input.btn {
     background: orange;
   }

--- a/angularjs/manageVersion/edit.directive.less
+++ b/angularjs/manageVersion/edit.directive.less
@@ -1,5 +1,5 @@
 .no-publish {
   input.btn {
-    background: orange;
+    background: #f57c00;
   }
 }

--- a/angularjs/manageVersion/manage.directive.less
+++ b/angularjs/manageVersion/manage.directive.less
@@ -1,0 +1,5 @@
+.createButton {
+  input.btn {
+    background: orange;
+  }
+}

--- a/tests/UI/expected-screenshots/ContainerVersion_create_through_menu_prefilled.png
+++ b/tests/UI/expected-screenshots/ContainerVersion_create_through_menu_prefilled.png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:38b1ff436bc7663a38b35e6117d952902b38e3ed78af2484b20a1ec861226287
-size 149403
+oid sha256:1fbddad2f5c20826cb22997d62180bddcba1325f1d66e120409b5bd1138f86fa
+size 148890

--- a/tests/UI/expected-screenshots/ContainerVersion_create_through_menu_prefilled.png
+++ b/tests/UI/expected-screenshots/ContainerVersion_create_through_menu_prefilled.png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:1fbddad2f5c20826cb22997d62180bddcba1325f1d66e120409b5bd1138f86fa
-size 148890
+oid sha256:1dfa982770655aa9650dccd2504338d99218104eb1c627504af3ac2d76a1697c
+size 149267


### PR DESCRIPTION
### Description:

Changed color of new version without publishing btn to orange.
Fixes: #415.

### Review

* [ ] [Functional review done](https://developer.matomo.org/guides/pull-request-reviews#functional-review-done)
* [ ] [Potential edge cases thought about](https://developer.matomo.org/guides/pull-request-reviews#potential-edge-cases-thought-about) (behavior of the code with strange input, with strange internal state or possible interactions with other Matomo subsystems)
* [ ] [Usability review done](https://developer.matomo.org/guides/pull-request-reviews#usability-review-done) (is anything maybe unclear or think about anything that would cause people to reach out to support)
* [ ] [Security review done](https://developer.matomo.org/guides/security-in-piwik#checklist)
* [ ] [Wording review done](https://developer.matomo.org/guides/pull-request-reviews#translations-wording-review-done)
* [ ] [Code review done](https://developer.matomo.org/guides/pull-request-reviews#code-review-done)
* [ ] [Tests were added if useful/possible](https://developer.matomo.org/guides/pull-request-reviews#tests-were-added-if-usefulpossible)
* [ ] [Reviewed for breaking changes](https://developer.matomo.org/guides/pull-request-reviews#reviewed-for-breaking-changes)
* [ ] [Developer changelog updated if needed](https://developer.matomo.org/guides/pull-request-reviews#developer-changelog-updated-if-needed)
* [ ] [Documentation added if needed](https://developer.matomo.org/guides/pull-request-reviews#documentation-added-if-needed)
* [ ] Existing documentation updated if needed
