### PR TITLE
started updating xdebug.max_nesting_level to 2500 if lower value set

### DIFF
--- a/API.php
+++ b/API.php
@@ -125,6 +125,13 @@ class API extends \Piwik\Plugin\API
 
     public function __construct(Tag $tags, Trigger $triggers, Variable $variables, Container $containers, TagsProvider $tagsProvider, TriggersProvider $triggersProvider, VariablesProvider $variablesProvider, ContextProvider $contextProvider, AccessValidator $validator, Environment $environment, Comparison $comparisons, Export $export, Import $import, VariablesDao $variablesDao)
     {
+        //Started updating xdebug.max_nesting_level as infinite loop is detected due to variable is doing a self referencing when xdebug is active and max_nesting_level is set to lower value
+        if (extension_loaded('xdebug')) {
+            $xdebugMaxNestingLevel = ini_get('xdebug.max_nesting_level');
+            if ($xdebugMaxNestingLevel && is_numeric($xdebugMaxNestingLevel) && $xdebugMaxNestingLevel < 2500) {
+                ini_set('xdebug.max_nesting_level', 2500);
+            }
+        }
         $this->tags = $tags;
         $this->triggers = $triggers;
         $this->variables = $variables;

--- a/TagManager.php
+++ b/TagManager.php
@@ -40,6 +40,17 @@ class TagManager extends \Piwik\Plugin
 {
     public static $enableAutoContainerCreation = true;
 
+    public function __construct($pluginName = false)
+    {
+        parent::__construct();
+        if (extension_loaded('xdebug')) {
+            $xdebugMaxNestingLevel = ini_get('xdebug.max_nesting_level');
+            if ($xdebugMaxNestingLevel && is_numeric($xdebugMaxNestingLevel) && $xdebugMaxNestingLevel < 2500) {
+                ini_set('xdebug.max_nesting_level', 2500);
+            }
+        }
+    }
+
     public function registerEvents()
     {
         return array(

--- a/TagManager.php
+++ b/TagManager.php
@@ -40,19 +40,14 @@ class TagManager extends \Piwik\Plugin
 {
     public static $enableAutoContainerCreation = true;
 
-    public function __construct($pluginName = false)
+    public function registerEvents()
     {
-        parent::__construct();
         if (extension_loaded('xdebug')) {
             $xdebugMaxNestingLevel = ini_get('xdebug.max_nesting_level');
             if ($xdebugMaxNestingLevel && is_numeric($xdebugMaxNestingLevel) && $xdebugMaxNestingLevel < 2500) {
                 ini_set('xdebug.max_nesting_level', 2500);
             }
         }
-    }
-
-    public function registerEvents()
-    {
         return array(
             'AssetManager.getStylesheetFiles' => 'getStylesheetFiles',
             'AssetManager.getJavaScriptFiles' => 'getJsFiles',

--- a/TagManager.php
+++ b/TagManager.php
@@ -42,12 +42,6 @@ class TagManager extends \Piwik\Plugin
 
     public function registerEvents()
     {
-        if (extension_loaded('xdebug')) {
-            $xdebugMaxNestingLevel = ini_get('xdebug.max_nesting_level');
-            if ($xdebugMaxNestingLevel && is_numeric($xdebugMaxNestingLevel) && $xdebugMaxNestingLevel < 2500) {
-                ini_set('xdebug.max_nesting_level', 2500);
-            }
-        }
         return array(
             'AssetManager.getStylesheetFiles' => 'getStylesheetFiles',
             'AssetManager.getJavaScriptFiles' => 'getJsFiles',


### PR DESCRIPTION
started updating xdebug.max_nesting_level to 2500 if lower value set
Fixes: #337 

### Description:

Please include a description of this change and which issue it fixes. If no issue exists yet please include context and what problem it solves.

### Review

* [ ] [Functional review done](https://developer.matomo.org/guides/pull-request-reviews#functional-review-done)
* [ ] [Potential edge cases thought about](https://developer.matomo.org/guides/pull-request-reviews#potential-edge-cases-thought-about) (behavior of the code with strange input, with strange internal state or possible interactions with other Matomo subsystems)
* [ ] [Usability review done](https://developer.matomo.org/guides/pull-request-reviews#usability-review-done) (is anything maybe unclear or think about anything that would cause people to reach out to support)
* [ ] [Security review done](https://developer.matomo.org/guides/security-in-piwik#checklist)
* [ ] [Wording review done](https://developer.matomo.org/guides/pull-request-reviews#translations-wording-review-done)
* [ ] [Code review done](https://developer.matomo.org/guides/pull-request-reviews#code-review-done)
* [ ] [Tests were added if useful/possible](https://developer.matomo.org/guides/pull-request-reviews#tests-were-added-if-usefulpossible)
* [ ] [Reviewed for breaking changes](https://developer.matomo.org/guides/pull-request-reviews#reviewed-for-breaking-changes)
* [ ] [Developer changelog updated if needed](https://developer.matomo.org/guides/pull-request-reviews#developer-changelog-updated-if-needed)
* [ ] [Documentation added if needed](https://developer.matomo.org/guides/pull-request-reviews#documentation-added-if-needed)
* [ ] Existing documentation updated if needed
