### PR TITLE
Updated so that javascript that's part of customHtml tags uses the no…

### DIFF
--- a/Template/Tag/CustomHtmlTag.web.js
+++ b/Template/Tag/CustomHtmlTag.web.js
@@ -127,9 +127,12 @@
 
             // If this script is executing using a nonce, set the nonce on its children too.
             var scriptWithNonce = TagManager.dom.bySelector('script[nonce]');
-            if (Array.isArray(scriptWithNonce) && scriptWithNonce.length) {
+            if (scriptWithNonce.length && scriptWithNonce[0]) {
                 scriptWithNonce = scriptWithNonce[0]; // Grab the first element.
-                newScript.nonce = scriptWithNonce.nonce;
+                // Try using the attribute first for compatibility, then go to the property.
+                var nonceAttr = TagManager.dom.getElementAttribute(scriptWithNonce, 'nonce');
+                nonceAttr = nonceAttr ? nonceAttr : scriptWithNonce.nonce;
+                newScript.setAttribute('nonce', nonceAttr);
             }
 
             return newScript;

--- a/Template/Tag/CustomHtmlTag.web.js
+++ b/Template/Tag/CustomHtmlTag.web.js
@@ -126,8 +126,9 @@
             }
 
             // If this script is executing using a nonce, set the nonce on its children too.
-            var scriptWithNonce = document.querySelector('script[nonce]');
-            if (typeof scriptWithNonce !== 'undefined') {
+            var scriptWithNonce = TagManager.dom.bySelector('script[nonce]');
+            if (Array.isArray(scriptWithNonce) && scriptWithNonce.length) {
+                scriptWithNonce = scriptWithNonce[0]; // Grab the first element.
                 newScript.nonce = scriptWithNonce.nonce;
             }
 

--- a/Template/Tag/CustomHtmlTag.web.js
+++ b/Template/Tag/CustomHtmlTag.web.js
@@ -125,6 +125,12 @@
                 newScript.setAttribute('type', element.getAttribute('type'));
             }
 
+            // If this script is executing using a nonce, set the nonce on its children too.
+            var scriptWithNonce = document.querySelector('script[nonce]');
+            if (typeof scriptWithNonce !== 'undefined') {
+                newScript.nonce = scriptWithNonce.nonce;
+            }
+
             return newScript;
         }
 

--- a/tests/System/expected/context_webcontext_generate.text
+++ b/tests/System/expected/context_webcontext_generate.text
@@ -23,6 +23,7 @@ if(element.hasAttribute(\'defer\')){newScript.setAttribute(\'defer\',element.get
 if(element.hasAttribute(\'async\')){newScript.setAttribute(\'async\',element.getAttribute(\'async\'));}
 if(element.hasAttribute(\'onload\')){newScript.setAttribute(\'onload\',element.getAttribute(\'onload\'));}
 if(element.hasAttribute(\'type\')){newScript.setAttribute(\'type\',element.getAttribute(\'type\'));}
+var scriptWithNonce=TagManager.dom.bySelector(\'script[nonce]\');if(Array.isArray(scriptWithNonce)&&scriptWithNonce.length){scriptWithNonce=scriptWithNonce[0];newScript.nonce=scriptWithNonce.nonce;}
 return newScript;}
 function isJavaScriptElement(element){if(element&&element.nodeName&&element.nodeName.toLowerCase()===\'script\'){var type=TagManager.dom.getElementAttribute(element,\'type\');if(!type||String(type).toLowerCase()===\'text/javascript\'){return true;}}
 return false;}
@@ -65,6 +66,7 @@ if(element.hasAttribute(\'defer\')){newScript.setAttribute(\'defer\',element.get
 if(element.hasAttribute(\'async\')){newScript.setAttribute(\'async\',element.getAttribute(\'async\'));}
 if(element.hasAttribute(\'onload\')){newScript.setAttribute(\'onload\',element.getAttribute(\'onload\'));}
 if(element.hasAttribute(\'type\')){newScript.setAttribute(\'type\',element.getAttribute(\'type\'));}
+var scriptWithNonce=TagManager.dom.bySelector(\'script[nonce]\');if(Array.isArray(scriptWithNonce)&&scriptWithNonce.length){scriptWithNonce=scriptWithNonce[0];newScript.nonce=scriptWithNonce.nonce;}
 return newScript;}
 function isJavaScriptElement(element){if(element&&element.nodeName&&element.nodeName.toLowerCase()===\'script\'){var type=TagManager.dom.getElementAttribute(element,\'type\');if(!type||String(type).toLowerCase()===\'text/javascript\'){return true;}}
 return false;}
@@ -107,6 +109,7 @@ if(element.hasAttribute(\'defer\')){newScript.setAttribute(\'defer\',element.get
 if(element.hasAttribute(\'async\')){newScript.setAttribute(\'async\',element.getAttribute(\'async\'));}
 if(element.hasAttribute(\'onload\')){newScript.setAttribute(\'onload\',element.getAttribute(\'onload\'));}
 if(element.hasAttribute(\'type\')){newScript.setAttribute(\'type\',element.getAttribute(\'type\'));}
+var scriptWithNonce=TagManager.dom.bySelector(\'script[nonce]\');if(Array.isArray(scriptWithNonce)&&scriptWithNonce.length){scriptWithNonce=scriptWithNonce[0];newScript.nonce=scriptWithNonce.nonce;}
 return newScript;}
 function isJavaScriptElement(element){if(element&&element.nodeName&&element.nodeName.toLowerCase()===\'script\'){var type=TagManager.dom.getElementAttribute(element,\'type\');if(!type||String(type).toLowerCase()===\'text/javascript\'){return true;}}
 return false;}
@@ -274,6 +277,7 @@ if(element.hasAttribute(\'defer\')){newScript.setAttribute(\'defer\',element.get
 if(element.hasAttribute(\'async\')){newScript.setAttribute(\'async\',element.getAttribute(\'async\'));}
 if(element.hasAttribute(\'onload\')){newScript.setAttribute(\'onload\',element.getAttribute(\'onload\'));}
 if(element.hasAttribute(\'type\')){newScript.setAttribute(\'type\',element.getAttribute(\'type\'));}
+var scriptWithNonce=TagManager.dom.bySelector(\'script[nonce]\');if(Array.isArray(scriptWithNonce)&&scriptWithNonce.length){scriptWithNonce=scriptWithNonce[0];newScript.nonce=scriptWithNonce.nonce;}
 return newScript;}
 function isJavaScriptElement(element){if(element&&element.nodeName&&element.nodeName.toLowerCase()===\'script\'){var type=TagManager.dom.getElementAttribute(element,\'type\');if(!type||String(type).toLowerCase()===\'text/javascript\'){return true;}}
 return false;}

--- a/tests/System/expected/context_webcontext_generate.text
+++ b/tests/System/expected/context_webcontext_generate.text
@@ -23,7 +23,7 @@ if(element.hasAttribute(\'defer\')){newScript.setAttribute(\'defer\',element.get
 if(element.hasAttribute(\'async\')){newScript.setAttribute(\'async\',element.getAttribute(\'async\'));}
 if(element.hasAttribute(\'onload\')){newScript.setAttribute(\'onload\',element.getAttribute(\'onload\'));}
 if(element.hasAttribute(\'type\')){newScript.setAttribute(\'type\',element.getAttribute(\'type\'));}
-var scriptWithNonce=TagManager.dom.bySelector(\'script[nonce]\');if(Array.isArray(scriptWithNonce)&&scriptWithNonce.length){scriptWithNonce=scriptWithNonce[0];newScript.nonce=scriptWithNonce.nonce;}
+var scriptWithNonce=TagManager.dom.bySelector(\'script[nonce]\');if(scriptWithNonce.length&&scriptWithNonce[0]){scriptWithNonce=scriptWithNonce[0];var nonceAttr=TagManager.dom.getElementAttribute(scriptWithNonce,\'nonce\');nonceAttr=nonceAttr?nonceAttr:scriptWithNonce.nonce;newScript.setAttribute(\'nonce\',nonceAttr);}
 return newScript;}
 function isJavaScriptElement(element){if(element&&element.nodeName&&element.nodeName.toLowerCase()===\'script\'){var type=TagManager.dom.getElementAttribute(element,\'type\');if(!type||String(type).toLowerCase()===\'text/javascript\'){return true;}}
 return false;}
@@ -66,7 +66,7 @@ if(element.hasAttribute(\'defer\')){newScript.setAttribute(\'defer\',element.get
 if(element.hasAttribute(\'async\')){newScript.setAttribute(\'async\',element.getAttribute(\'async\'));}
 if(element.hasAttribute(\'onload\')){newScript.setAttribute(\'onload\',element.getAttribute(\'onload\'));}
 if(element.hasAttribute(\'type\')){newScript.setAttribute(\'type\',element.getAttribute(\'type\'));}
-var scriptWithNonce=TagManager.dom.bySelector(\'script[nonce]\');if(Array.isArray(scriptWithNonce)&&scriptWithNonce.length){scriptWithNonce=scriptWithNonce[0];newScript.nonce=scriptWithNonce.nonce;}
+var scriptWithNonce=TagManager.dom.bySelector(\'script[nonce]\');if(scriptWithNonce.length&&scriptWithNonce[0]){scriptWithNonce=scriptWithNonce[0];var nonceAttr=TagManager.dom.getElementAttribute(scriptWithNonce,\'nonce\');nonceAttr=nonceAttr?nonceAttr:scriptWithNonce.nonce;newScript.setAttribute(\'nonce\',nonceAttr);}
 return newScript;}
 function isJavaScriptElement(element){if(element&&element.nodeName&&element.nodeName.toLowerCase()===\'script\'){var type=TagManager.dom.getElementAttribute(element,\'type\');if(!type||String(type).toLowerCase()===\'text/javascript\'){return true;}}
 return false;}
@@ -109,7 +109,7 @@ if(element.hasAttribute(\'defer\')){newScript.setAttribute(\'defer\',element.get
 if(element.hasAttribute(\'async\')){newScript.setAttribute(\'async\',element.getAttribute(\'async\'));}
 if(element.hasAttribute(\'onload\')){newScript.setAttribute(\'onload\',element.getAttribute(\'onload\'));}
 if(element.hasAttribute(\'type\')){newScript.setAttribute(\'type\',element.getAttribute(\'type\'));}
-var scriptWithNonce=TagManager.dom.bySelector(\'script[nonce]\');if(Array.isArray(scriptWithNonce)&&scriptWithNonce.length){scriptWithNonce=scriptWithNonce[0];newScript.nonce=scriptWithNonce.nonce;}
+var scriptWithNonce=TagManager.dom.bySelector(\'script[nonce]\');if(scriptWithNonce.length&&scriptWithNonce[0]){scriptWithNonce=scriptWithNonce[0];var nonceAttr=TagManager.dom.getElementAttribute(scriptWithNonce,\'nonce\');nonceAttr=nonceAttr?nonceAttr:scriptWithNonce.nonce;newScript.setAttribute(\'nonce\',nonceAttr);}
 return newScript;}
 function isJavaScriptElement(element){if(element&&element.nodeName&&element.nodeName.toLowerCase()===\'script\'){var type=TagManager.dom.getElementAttribute(element,\'type\');if(!type||String(type).toLowerCase()===\'text/javascript\'){return true;}}
 return false;}
@@ -277,7 +277,7 @@ if(element.hasAttribute(\'defer\')){newScript.setAttribute(\'defer\',element.get
 if(element.hasAttribute(\'async\')){newScript.setAttribute(\'async\',element.getAttribute(\'async\'));}
 if(element.hasAttribute(\'onload\')){newScript.setAttribute(\'onload\',element.getAttribute(\'onload\'));}
 if(element.hasAttribute(\'type\')){newScript.setAttribute(\'type\',element.getAttribute(\'type\'));}
-var scriptWithNonce=TagManager.dom.bySelector(\'script[nonce]\');if(Array.isArray(scriptWithNonce)&&scriptWithNonce.length){scriptWithNonce=scriptWithNonce[0];newScript.nonce=scriptWithNonce.nonce;}
+var scriptWithNonce=TagManager.dom.bySelector(\'script[nonce]\');if(scriptWithNonce.length&&scriptWithNonce[0]){scriptWithNonce=scriptWithNonce[0];var nonceAttr=TagManager.dom.getElementAttribute(scriptWithNonce,\'nonce\');nonceAttr=nonceAttr?nonceAttr:scriptWithNonce.nonce;newScript.setAttribute(\'nonce\',nonceAttr);}
 return newScript;}
 function isJavaScriptElement(element){if(element&&element.nodeName&&element.nodeName.toLowerCase()===\'script\'){var type=TagManager.dom.getElementAttribute(element,\'type\');if(!type||String(type).toLowerCase()===\'text/javascript\'){return true;}}
 return false;}

--- a/tests/javascript/index.php
+++ b/tests/javascript/index.php
@@ -2549,7 +2549,10 @@
             fireTemplateTag(templateToTest, params);
             var addedStyle4 = document.getElementById('customStyleTag4');
             strictEqual('var x = {};', addedStyle4.innerText, 'should have added element to start of head');
-            strictEqual('abc123123', addedStyle4.nonce, 'should have inherited nonce from main script');
+            // Use attribute for compatibility.
+            var nonceAttr = addedStyle4.getAttribute('nonce');
+            nonceAttr = nonceAttr ? nonceAttr : addedStyle4.nonce;
+            strictEqual('abc123123', nonceAttr, 'should have inherited nonce from main script');
             document.head.removeChild(addedStyle4);
 
             // auto escapes JS when through variable

--- a/tests/javascript/index.php
+++ b/tests/javascript/index.php
@@ -49,7 +49,7 @@
 <a href="https://www.example.click/foo/bar" id="ClickTagManager2">my link</a>
 <a href="https://www.example.click/foo/bar3" id="ClickTagManager3"><span><span id="ClickTagManager3Span">my link</span></span></a>
 
-<script type="text/javascript">
+<script type="text/javascript" nonce="abc123123">
 
     (function () {
 
@@ -2518,7 +2518,7 @@
         });
 
         test("Matomo TagManager Template CustomHtmlTag", function() {
-            expect(10);
+            expect(11);
             var templateToTest = 'CustomHtmlTag';
             var params = {document: document, customHtml: buildVariable('<div id="customHtmlTag1">my foo bar baz test</div><div id="customHtmlTag2">my test</div>')};
 
@@ -2549,6 +2549,7 @@
             fireTemplateTag(templateToTest, params);
             var addedStyle4 = document.getElementById('customStyleTag4');
             strictEqual('var x = {};', addedStyle4.innerText, 'should have added element to start of head');
+            strictEqual('abc123123', addedStyle4.nonce, 'should have inherited nonce from main script');
             document.head.removeChild(addedStyle4);
 
             // auto escapes JS when through variable


### PR DESCRIPTION
### Description:

Updated the Tag javascript file so that when a customHtml tag includes javascript, it checks if the main script has a nonce and copies it to the custom javascript so that it works with CSP.
Fixes: #326 
@tsteur This is a security issue, so I thought it would be good to have you look at it and make sure I'm not creating a vulnerability.

### Review

* [ ] [Functional review done](https://developer.matomo.org/guides/pull-request-reviews#functional-review-done)
* [ ] [Potential edge cases thought about](https://developer.matomo.org/guides/pull-request-reviews#potential-edge-cases-thought-about) (behavior of the code with strange input, with strange internal state or possible interactions with other Matomo subsystems)
* [ ] [Usability review done](https://developer.matomo.org/guides/pull-request-reviews#usability-review-done) (is anything maybe unclear or think about anything that would cause people to reach out to support)
* [ ] [Security review done](https://developer.matomo.org/guides/security-in-piwik#checklist)
* [ ] [Wording review done](https://developer.matomo.org/guides/pull-request-reviews#translations-wording-review-done)
* [ ] [Code review done](https://developer.matomo.org/guides/pull-request-reviews#code-review-done)
* [ ] [Tests were added if useful/possible](https://developer.matomo.org/guides/pull-request-reviews#tests-were-added-if-usefulpossible)
* [ ] [Reviewed for breaking changes](https://developer.matomo.org/guides/pull-request-reviews#reviewed-for-breaking-changes)
* [ ] [Developer changelog updated if needed](https://developer.matomo.org/guides/pull-request-reviews#developer-changelog-updated-if-needed)
* [ ] [Documentation added if needed](https://developer.matomo.org/guides/pull-request-reviews#documentation-added-if-needed)
* [ ] Existing documentation updated if needed
