### PR TITLE
When clicking an element within a shadow DOM, use it as the target instead of the shadow root

### DIFF
--- a/Template/Trigger/AllDownloadsClickTrigger.web.js
+++ b/Template/Trigger/AllDownloadsClickTrigger.web.js
@@ -21,11 +21,14 @@
                         return;
                     }
 
-                    var target = event.target;
+                    var target = event.target;                    
                     if (target.shadowRoot) {
-                        target = event.composedPath()[0];
+                        var composedPath = event.composedPath();
+                        if (composedPath.length) {
+                            target = composedPath[0];   //In shadow DOM select the first event path as the target
+                        }
                     }
-                    
+
                     var nodeName = target.nodeName;
 
                     while (!isClickNode(nodeName) && target && target.parentNode) {

--- a/Template/Trigger/AllDownloadsClickTrigger.web.js
+++ b/Template/Trigger/AllDownloadsClickTrigger.web.js
@@ -22,6 +22,10 @@
                     }
 
                     var target = event.target;
+                    if (target.shadowRoot) {
+                        target = event.composedPath()[0];
+                    }
+                    
                     var nodeName = target.nodeName;
 
                     while (!isClickNode(nodeName) && target && target.parentNode) {

--- a/Template/Trigger/AllElementsClickTrigger.web.js
+++ b/Template/Trigger/AllElementsClickTrigger.web.js
@@ -13,6 +13,11 @@
                 return;
             }
             var target = event.target;
+
+            if (target.shadowRoot) {
+                target = event.composedPath()[0];
+            }
+
             triggerEvent({
                 event: 'mtm.AllElementsClick',
                 'mtm.clickElement': target,

--- a/Template/Trigger/AllElementsClickTrigger.web.js
+++ b/Template/Trigger/AllElementsClickTrigger.web.js
@@ -12,10 +12,13 @@
             if (!event.target) {
                 return;
             }
-            var target = event.target;
 
+            var target = event.target;
             if (target.shadowRoot) {
-                target = event.composedPath()[0];
+                var composedPath = event.composedPath();
+                if (composedPath.length) {
+                      target = composedPath[0];   //In shadow DOM select the first event path as the target
+                }
             }
 
             triggerEvent({

--- a/Template/Trigger/AllLinksClickTrigger.web.js
+++ b/Template/Trigger/AllLinksClickTrigger.web.js
@@ -18,9 +18,12 @@
                         return;
                     }
 
-                    var target = event.target;
+                    var target = event.target;                    
                     if (target.shadowRoot) {
-                        target = event.composedPath()[0];
+                        var composedPath = event.composedPath();
+                        if (composedPath.length) {
+                            target = composedPath[0];   //In shadow DOM select the first event path as the target
+                        }
                     }
                     
                     var nodeName = target.nodeName;

--- a/Template/Trigger/AllLinksClickTrigger.web.js
+++ b/Template/Trigger/AllLinksClickTrigger.web.js
@@ -19,6 +19,10 @@
                     }
 
                     var target = event.target;
+                    if (target.shadowRoot) {
+                        target = event.composedPath()[0];
+                    }
+                    
                     var nodeName = target.nodeName;
 
                     while (!isClickNode(nodeName) && target && target.parentNode) {


### PR DESCRIPTION
### Description:

This code change enhances the AllElementsClickedTrigger to fire event on the actual clicked target when inside an (open) shadow dom.
Fixes: #543 

### Review

* [ ] [Functional review done](https://developer.matomo.org/guides/pull-request-reviews#functional-review-done)
* [ ] [Potential edge cases thought about](https://developer.matomo.org/guides/pull-request-reviews#potential-edge-cases-thought-about) (behavior of the code with strange input, with strange internal state or possible interactions with other Matomo subsystems)
* [ ] [Usability review done](https://developer.matomo.org/guides/pull-request-reviews#usability-review-done) (is anything maybe unclear or think about anything that would cause people to reach out to support)
* [ ] [Security review done](https://developer.matomo.org/guides/security-in-piwik#checklist)
* [ ] [Wording review done](https://developer.matomo.org/guides/pull-request-reviews#translations-wording-review-done)
* [ ] [Code review done](https://developer.matomo.org/guides/pull-request-reviews#code-review-done)
* [ ] [Tests were added if useful/possible](https://developer.matomo.org/guides/pull-request-reviews#tests-were-added-if-usefulpossible)
* [ ] [Reviewed for breaking changes](https://developer.matomo.org/guides/pull-request-reviews#reviewed-for-breaking-changes)
* [ ] [Developer changelog updated if needed](https://developer.matomo.org/guides/pull-request-reviews#developer-changelog-updated-if-needed)
* [ ] [Documentation added if needed](https://developer.matomo.org/guides/pull-request-reviews#documentation-added-if-needed)
* [ ] Existing documentation updated if needed
