### PR TITLE
Fix a translation key not being registered with the client

### DIFF
--- a/TagManager.php
+++ b/TagManager.php
@@ -568,6 +568,7 @@ class TagManager extends \Piwik\Plugin
         $result[] = 'TagManager_VersionsEnvironmentsDescription';
         $result[] = 'TagManager_VersionsCreatedDescription';
         $result[] = 'TagManager_VersionsActionDescription';
+        $result[] = 'TagManager_CreateNewVersionNow';
     }
 
     public function getStylesheetFiles(&$stylesheets)


### PR DESCRIPTION
### Description:

There was a translation key that was missed while adding new keys to the list of translations registered with the client.
Fixes: #559 

### Review

* [ ] [Functional review done](https://developer.matomo.org/guides/pull-request-reviews#functional-review-done)
* [ ] [Potential edge cases thought about](https://developer.matomo.org/guides/pull-request-reviews#potential-edge-cases-thought-about) (behavior of the code with strange input, with strange internal state or possible interactions with other Matomo subsystems)
* [ ] [Usability review done](https://developer.matomo.org/guides/pull-request-reviews#usability-review-done) (is anything maybe unclear or think about anything that would cause people to reach out to support)
* [ ] [Security review done](https://developer.matomo.org/guides/security-in-piwik#checklist)
* [ ] [Wording review done](https://developer.matomo.org/guides/pull-request-reviews#translations-wording-review-done)
* [ ] [Code review done](https://developer.matomo.org/guides/pull-request-reviews#code-review-done)
* [ ] [Tests were added if useful/possible](https://developer.matomo.org/guides/pull-request-reviews#tests-were-added-if-usefulpossible)
* [ ] [Reviewed for breaking changes](https://developer.matomo.org/guides/pull-request-reviews#reviewed-for-breaking-changes)
* [ ] [Developer changelog updated if needed](https://developer.matomo.org/guides/pull-request-reviews#developer-changelog-updated-if-needed)
* [ ] [Documentation added if needed](https://developer.matomo.org/guides/pull-request-reviews#documentation-added-if-needed)
* [ ] Existing documentation updated if needed
