### PR TITLE
Add escaping for percent sign for ScrollReachTriggerPercentageDescription key

### DIFF
--- a/lang/en.json
+++ b/lang/en.json
@@ -846,7 +846,7 @@
         "ScrollReachTriggerPixelsTitle": "Pixels",
         "ScrollReachTriggerPixelsDescription": "The amount in pixels that needs to be visible of this element depending on the selected scroll match type.",
         "ScrollReachTriggerPercentageTitle": "Percentage",
-        "ScrollReachTriggerPercentageDescription": "You can specify any number between 1 and 100. If you specify 50, then it means the element needs to be at least 50% visible depending on the scroll match type.",
+        "ScrollReachTriggerPercentageDescription": "You can specify any number between 1 and 100. If you specify 50, then it means the element needs to be at least 50%% visible depending on the scroll match type.",
         "TimerTriggerTriggerIntervalTitle": "Trigger interval",
         "TimerTriggerEventNameDescription": "You can optionally change the name of this event. This can be useful if you have for example multiple timers on the page and want to perform different logic based on the name of the timer.",
         "TimerTriggerTriggerLimitTitle": "Trigger limit",


### PR DESCRIPTION
### Description:

Added escaping for percent for ScrollReachTriggerPercentageDescription key.

### Review

* [ ] [Functional review done](https://developer.matomo.org/guides/pull-request-reviews#functional-review-done)
* [ ] [Potential edge cases thought about](https://developer.matomo.org/guides/pull-request-reviews#potential-edge-cases-thought-about) (behavior of the code with strange input, with strange internal state or possible interactions with other Matomo subsystems)
* [ ] [Usability review done](https://developer.matomo.org/guides/pull-request-reviews#usability-review-done) (is anything maybe unclear or think about anything that would cause people to reach out to support)
* [ ] [Security review done](https://developer.matomo.org/guides/security-in-piwik#checklist)
* [ ] [Wording review done](https://developer.matomo.org/guides/pull-request-reviews#translations-wording-review-done)
* [ ] [Code review done](https://developer.matomo.org/guides/pull-request-reviews#code-review-done)
* [ ] [Tests were added if useful/possible](https://developer.matomo.org/guides/pull-request-reviews#tests-were-added-if-usefulpossible)
* [ ] [Reviewed for breaking changes](https://developer.matomo.org/guides/pull-request-reviews#reviewed-for-breaking-changes)
* [ ] [Developer changelog updated if needed](https://developer.matomo.org/guides/pull-request-reviews#developer-changelog-updated-if-needed)
* [ ] [Documentation added if needed](https://developer.matomo.org/guides/pull-request-reviews#documentation-added-if-needed)
* [ ] Existing documentation updated if needed
