### PR TITLE
Moved migration helpers to avoid migration error

### DIFF
--- a/UpdateHelper/NewTagParameterMigrator.php
+++ b/UpdateHelper/NewTagParameterMigrator.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace Piwik\Plugins\TagManager\Updates;
+namespace Piwik\Plugins\TagManager\UpdateHelper;
 
 use Piwik\Container\StaticContainer;
 use Piwik\Date;

--- a/UpdateHelper/NewVariableParameterMigrator.php
+++ b/UpdateHelper/NewVariableParameterMigrator.php
@@ -109,6 +109,6 @@ class NewVariableParameterMigrator
         }
 
         // We use the model method to make sure that the parameters are set in the correct order.
-        $this->variablesModel->updateContainerVariable($idSite, $idVersion, $idVariable, $variableInfo['name'], $variableInfo['parameters'], $variableInfo['default_value'], $variableInfo['lookup_table']);
+        $this->variablesModel->updateContainerVariable($idSite, $idVersion, $idVariable, $variableInfo['name'], $variableInfo['parameters'], $variableInfo['default_value'], $variableInfo['lookup_table'], $variableInfo['description']);
     }
 }

--- a/UpdateHelper/NewVariableParameterMigrator.php
+++ b/UpdateHelper/NewVariableParameterMigrator.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace Piwik\Plugins\TagManager\Updates;
+namespace Piwik\Plugins\TagManager\UpdateHelper;
 
 use Piwik\Container\StaticContainer;
 use Piwik\Date;

--- a/Updates/4.12.3-b1.php
+++ b/Updates/4.12.3-b1.php
@@ -10,11 +10,11 @@
 namespace Piwik\Plugins\TagManager;
 
 use Piwik\Plugins\TagManager\Template\Tag\MatomoTag;
-use Piwik\Plugins\TagManager\Updates\NewTagParameterMigrator;
+use Piwik\Plugins\TagManager\UpdateHelper\NewTagParameterMigrator;
 use Piwik\Updater;
-use Piwik\Updates as PiwikUpdates;
 use Piwik\Updater\Migration;
 use Piwik\Updater\Migration\Factory as MigrationFactory;
+use Piwik\Updates as PiwikUpdates;
 
 /**
  * Update for version 4.12.3-b1.

--- a/Updates/4.12.4-b1.php
+++ b/Updates/4.12.4-b1.php
@@ -10,7 +10,7 @@
 namespace Piwik\Plugins\TagManager;
 
 use Piwik\Plugins\TagManager\Template\Variable\MatomoConfigurationVariable;
-use Piwik\Plugins\TagManager\Updates\NewVariableParameterMigrator;
+use Piwik\Plugins\TagManager\UpdateHelper\NewVariableParameterMigrator;
 use Piwik\Updater;
 use Piwik\Updates as PiwikUpdates;
 

--- a/Updates/5.0.0-b1.php
+++ b/Updates/5.0.0-b1.php
@@ -10,11 +10,11 @@
 namespace Piwik\Plugins\TagManager;
 
 use Piwik\Plugins\TagManager\Template\Variable\MatomoConfigurationVariable;
-use Piwik\Plugins\TagManager\Updates\NewVariableParameterMigrator;
+use Piwik\Plugins\TagManager\UpdateHelper\NewVariableParameterMigrator;
 use Piwik\Updater;
-use Piwik\Updates as PiwikUpdates;
 use Piwik\Updater\Migration;
 use Piwik\Updater\Migration\Factory as MigrationFactory;
+use Piwik\Updates as PiwikUpdates;
 
 /**
  * Update for version 5.0.0-b1.

--- a/tests/Integration/UpdateHelper/NewTagParameterMigratorTest.php
+++ b/tests/Integration/UpdateHelper/NewTagParameterMigratorTest.php
@@ -8,7 +8,6 @@
 
 namespace Piwik\Plugins\TagManager\tests\Integration;
 
-use Piwik\Config;
 use Piwik\Plugins\TagManager\Context\WebContext;
 use Piwik\Plugins\TagManager\Dao\ContainersDao;
 use Piwik\Plugins\TagManager\Dao\ContainerVersionsDao;
@@ -16,7 +15,7 @@ use Piwik\Plugins\TagManager\Dao\TagsDao;
 use Piwik\Plugins\TagManager\Model\Tag;
 use Piwik\Plugins\TagManager\Template\Tag\CustomHtmlTag;
 use Piwik\Plugins\TagManager\Template\Tag\MatomoTag;
-use Piwik\Plugins\TagManager\Updates\NewTagParameterMigrator;
+use Piwik\Plugins\TagManager\UpdateHelper\NewTagParameterMigrator;
 use Piwik\Tests\Framework\TestCase\IntegrationTestCase;
 
 /**

--- a/tests/Integration/UpdateHelper/NewTagParameterMigratorTest.php
+++ b/tests/Integration/UpdateHelper/NewTagParameterMigratorTest.php
@@ -56,7 +56,7 @@ class NewTagParameterMigratorTest extends IntegrationTestCase
             $parameters[MatomoTag::PARAM_MATOMO_CONFIG] = !empty($parameters[MatomoTag::PARAM_MATOMO_CONFIG]) ? $parameters[MatomoTag::PARAM_MATOMO_CONFIG] : 'someConfig';
         }
 
-        return $this->tagDao->createTag($this->idSite, $idVersion, $type, $name, $parameters, $fireTriggerIds, $blockTriggerIds, $fireLimit, $fireDelay, $priority, $startDate, $endDate, $createdDate);
+        return $this->tagDao->createTag($this->idSite, $idVersion, $type, $name, $parameters, $fireTriggerIds, $blockTriggerIds, $fireLimit, $fireDelay, $priority, $startDate, $endDate, $createdDate, 'Test Tag Description');
     }
 
     public function test_migratingTagsWithNewField()
@@ -103,12 +103,14 @@ class NewTagParameterMigratorTest extends IntegrationTestCase
         $this->assertCount(2, $tag['parameters']);
         $this->assertArrayHasKey('goalCustomRevenue', $tag['parameters']);
         $this->assertSame('', $tag['parameters']['goalCustomRevenue']);
+        $this->assertNotEmpty($tag['description']);
 
         $tag = $this->tagDao->getContainerTag($this->idSite, $idVersion, $idCustomHtmlTag);
         $this->assertSame($idCustomHtmlTag, $tag['idtag']);
         $this->assertIsArray($tag);
         $this->assertIsArray($tag['parameters']);
         $this->assertCount(0, $tag['parameters']);
+        $this->assertNotEmpty($tag['description']);
 
         $tag = $this->tagDao->getContainerTag($this->idSite, $idVersion, $idTagWithParameters);
         $this->assertSame($idTagWithParameters, $tag['idtag']);
@@ -117,12 +119,14 @@ class NewTagParameterMigratorTest extends IntegrationTestCase
         $this->assertCount(3, $tag['parameters']);
         $this->assertArrayHasKey('goalCustomRevenue', $tag['parameters']);
         $this->assertSame('', $tag['parameters']['goalCustomRevenue']);
+        $this->assertNotEmpty($tag['description']);
 
         $tag = $this->tagDao->getContainerTagAnyStatus($this->idSite, $idVersion, $idDeletedTag);
         $this->assertSame($idDeletedTag, $tag['idtag']);
         $this->assertIsArray($tag);
         $this->assertIsArray($tag['parameters']);
         $this->assertCount(1, $tag['parameters']);
+        $this->assertNotEmpty($tag['description']);
 
         $tag = $this->tagDao->getContainerTag($this->idSite, $idDraftVersion, $idDraftVersionTag);
         $this->assertSame($idDraftVersionTag, $tag['idtag']);
@@ -131,18 +135,21 @@ class NewTagParameterMigratorTest extends IntegrationTestCase
         $this->assertCount(2, $tag['parameters']);
         $this->assertArrayHasKey('goalCustomRevenue', $tag['parameters']);
         $this->assertSame('', $tag['parameters']['goalCustomRevenue']);
+        $this->assertNotEmpty($tag['description']);
 
         $tag = $this->tagDao->getContainerTag($this->idSite, $idDeletedVersion, $idDeletedVersionTag);
         $this->assertSame($idDeletedVersionTag, $tag['idtag']);
         $this->assertIsArray($tag);
         $this->assertIsArray($tag['parameters']);
         $this->assertCount(1, $tag['parameters']);
+        $this->assertNotEmpty($tag['description']);
 
         $tag = $this->tagDao->getContainerTag($this->idSite, $idDeletedContainerVersion, $idDeletedContainerTag);
         $this->assertSame($idDeletedContainerTag, $tag['idtag']);
         $this->assertIsArray($tag);
         $this->assertIsArray($tag['parameters']);
         $this->assertCount(1, $tag['parameters']);
+        $this->assertNotEmpty($tag['description']);
     }
 
     public function test_migratingTagsWithNewFieldAndDefaultValue()
@@ -176,6 +183,7 @@ class NewTagParameterMigratorTest extends IntegrationTestCase
         $this->assertCount(2, $tag['parameters']);
         $this->assertArrayHasKey('goalCustomRevenue', $tag['parameters']);
         $this->assertSame('mynewvalue', $tag['parameters']['goalCustomRevenue']);
+        $this->assertNotEmpty($tag['description']);
     }
 
     public function test_migratingTagsWithAdditionalField()
@@ -214,6 +222,7 @@ class NewTagParameterMigratorTest extends IntegrationTestCase
         $this->assertArrayHasKey('documentTitle', $tag['parameters']);
         $this->assertSame('', $tag['parameters']['documentTitle']);
         $this->assertArrayNotHasKey('notValidTemplateProperty', $tag['parameters']);
+        $this->assertNotEmpty($tag['description']);
     }
 
 }

--- a/tests/Integration/UpdateHelper/NewVariableParameterMigratorTest.php
+++ b/tests/Integration/UpdateHelper/NewVariableParameterMigratorTest.php
@@ -1,0 +1,240 @@
+<?php
+/**
+ * Matomo - free/libre analytics platform
+ *
+ * @link https://matomo.org
+ * @license http://www.gnu.org/licenses/gpl-3.0.html GPL v3 or later
+ */
+
+namespace Piwik\Plugins\TagManager\tests\Integration;
+
+use Piwik\Plugins\TagManager\Context\WebContext;
+use Piwik\Plugins\TagManager\Dao\ContainersDao;
+use Piwik\Plugins\TagManager\Dao\ContainerVersionsDao;
+use Piwik\Plugins\TagManager\Dao\VariablesDao;
+use Piwik\Plugins\TagManager\Template\Variable\CustomJsFunctionVariable;
+use Piwik\Plugins\TagManager\Template\Variable\MatomoConfigurationVariable;
+use Piwik\Plugins\TagManager\tests\Fixtures\TagManagerFixture;
+use Piwik\Plugins\TagManager\UpdateHelper\NewVariableParameterMigrator;
+use Piwik\Tests\Framework\TestCase\IntegrationTestCase;
+
+/**
+ * @group TagManager
+ * @group NewVariableParameterMigrator
+ * @group Updates
+ * @group Plugins
+ */
+class NewVariableParameterMigratorTest extends IntegrationTestCase
+{
+    /**
+     * @var NewVariableParameterMigrator
+     */
+    private $newVariableParameterMigrator;
+
+    private $idSite;
+
+    /**
+     * @var VariablesDao
+     */
+    private $variableDao;
+
+    private $dateString;
+
+    public function setUp(): void
+    {
+        parent::setUp();
+
+        $this->tagFixture = new TagManagerFixture();
+        $this->tagFixture->setUpWebsite();
+
+        $this->newVariableParameterMigrator = new NewVariableParameterMigrator(MatomoConfigurationVariable::ID, 'cookieDomain');
+    }
+
+    private function createVariable($idVersion, $type = MatomoConfigurationVariable::ID, $name = '', $parameters = [])
+    {
+        $name = $name ?: uniqid('variableName');
+        $createdDate = $this->dateString;
+        $defaultValue = '';
+        $lookupTable = '';
+        $description = 'Test variable description';
+        if ($type === MatomoConfigurationVariable::ID) {
+            $parameters['idSite'] = !empty($parameters['idSite']) ? $parameters['idSite'] : $this->idSite;
+        }
+
+        return $this->variableDao->createVariable($this->idSite, $idVersion, $type, $name, $parameters, $defaultValue, $lookupTable, $createdDate, $description);
+    }
+
+    public function test_migratingVariablesWithNewField()
+    {
+        $this->dateString = '2015-01-01 01:02:03';
+
+        // Create some containers to test with.
+        $containerDao = new ContainersDao();
+        $this->idSite = 2;
+        $idContainer = 'abcdef';
+        $idDeletedContainer = 'deleted1';
+        $context = WebContext::ID;
+        $name = 'My Container';
+        $description = 'My container description';
+        $containerDao->createContainer($this->idSite, $idContainer, $context, $name, $description, $this->dateString);
+        $containerDao->createContainer($this->idSite, $idDeletedContainer, $context, uniqid($name), $description, $this->dateString);
+        $containerDao->deleteContainer($this->idSite, $idDeletedContainer, $this->dateString);
+
+        // Create some versions to test with.
+        $versionDao = new ContainerVersionsDao();
+        $idDraftVersion = $versionDao->createDraftVersion($this->idSite, $idContainer, $this->dateString);
+        $idVersion = $versionDao->createVersion($this->idSite, $idContainer, 'v1', '', $this->dateString);
+        $idDeletedVersion = $versionDao->createVersion($this->idSite, $idContainer, 'vdeleted', '', $this->dateString);
+        $idDeletedContainerVersion = $versionDao->createVersion($this->idSite, $idDeletedContainer, 'v1', '', $this->dateString);
+        $versionDao->deleteVersion($this->idSite, $idDeletedVersion, $this->dateString);
+
+        // Create some variables to test with.
+        $this->variableDao = new VariablesDao();
+        $idVariable = $this->createVariable($idVersion);
+        $idCustomJsFunctionVariable = $this->createVariable($idVersion, CustomJsFunctionVariable::ID, 'CustomJsFunction Variable Name');
+        $idVariableWithParameters = $this->createVariable($idVersion, MatomoConfigurationVariable::ID, 'Variable with parameters', [ 'idGoal' => '9' ]);
+        $idDeletedVariable = $this->createVariable($idVersion);
+        $this->variableDao->deleteContainerVariable($this->idSite, $idVersion, $idDeletedVariable, $this->dateString);
+        $idDraftVersionVariable = $this->createVariable($idDraftVersion);
+        $idDeletedVersionVariable = $this->createVariable($idDeletedVersion);
+        $idDeletedContainerVariable = $this->createVariable($idDeletedContainerVersion);
+
+        $this->newVariableParameterMigrator->migrate();
+
+        $variable = $this->variableDao->getContainerVariable($this->idSite, $idVersion, $idVariable);
+        $this->assertSame($idVariable, $variable['idvariable']);
+        $this->assertIsArray($variable);
+        $this->assertIsArray($variable['parameters']);
+        $this->assertCount(2, $variable['parameters']);
+        $this->assertArrayHasKey('cookieDomain', $variable['parameters']);
+        $this->assertSame('', $variable['parameters']['cookieDomain']);
+        $this->assertNotEmpty($variable['description']);
+
+        $variable = $this->variableDao->getContainerVariable($this->idSite, $idVersion, $idCustomJsFunctionVariable);
+        $this->assertSame($idCustomJsFunctionVariable, $variable['idvariable']);
+        $this->assertIsArray($variable);
+        $this->assertIsArray($variable['parameters']);
+        $this->assertCount(0, $variable['parameters']);
+        $this->assertNotEmpty($variable['description']);
+
+        $variable = $this->variableDao->getContainerVariable($this->idSite, $idVersion, $idVariableWithParameters);
+        $this->assertSame($idVariableWithParameters, $variable['idvariable']);
+        $this->assertIsArray($variable);
+        $this->assertIsArray($variable['parameters']);
+        $this->assertCount(2, $variable['parameters']);
+        $this->assertArrayHasKey('cookieDomain', $variable['parameters']);
+        $this->assertSame('', $variable['parameters']['cookieDomain']);
+        $this->assertNotEmpty($variable['description']);
+
+        // Find the deleted variable since the getContainerVariable method only works for active status variables.
+        $variables = $this->variableDao->getAllVariables();
+        foreach ($variables as $var) {
+            if ($var['idvariable'] === $idDeletedVariable) {
+                $variable = $var;
+                break;
+            }
+        }
+        $this->assertSame($idDeletedVariable, $variable['idvariable']);
+        $this->assertIsArray($variable);
+        $this->assertIsArray($variable['parameters']);
+        $this->assertCount(1, $variable['parameters']);
+        $this->assertNotEmpty($variable['description']);
+
+        $variable = $this->variableDao->getContainerVariable($this->idSite, $idDraftVersion, $idDraftVersionVariable);
+        $this->assertSame($idDraftVersionVariable, $variable['idvariable']);
+        $this->assertIsArray($variable);
+        $this->assertIsArray($variable['parameters']);
+        $this->assertCount(2, $variable['parameters']);
+        $this->assertArrayHasKey('cookieDomain', $variable['parameters']);
+        $this->assertSame('', $variable['parameters']['cookieDomain']);
+        $this->assertNotEmpty($variable['description']);
+
+        $variable = $this->variableDao->getContainerVariable($this->idSite, $idDeletedVersion, $idDeletedVersionVariable);
+        $this->assertSame($idDeletedVersionVariable, $variable['idvariable']);
+        $this->assertIsArray($variable);
+        $this->assertIsArray($variable['parameters']);
+        $this->assertCount(1, $variable['parameters']);
+        $this->assertNotEmpty($variable['description']);
+
+        $variable = $this->variableDao->getContainerVariable($this->idSite, $idDeletedContainerVersion, $idDeletedContainerVariable);
+        $this->assertSame($idDeletedContainerVariable, $variable['idvariable']);
+        $this->assertIsArray($variable);
+        $this->assertIsArray($variable['parameters']);
+        $this->assertCount(1, $variable['parameters']);
+        $this->assertNotEmpty($variable['description']);
+    }
+
+    public function test_migratingVariablesWithNewFieldAndDefaultValue()
+    {
+        $this->newVariableParameterMigrator = new NewVariableParameterMigrator(MatomoConfigurationVariable::ID, 'cookieDomain', 'myNewValue');
+        $this->dateString = '2015-01-01 01:02:03';
+
+        // Create some containers to test with.
+        $containerDao = new ContainersDao();
+        $this->idSite = 2;
+        $idContainer = 'abcdef';
+        $context = WebContext::ID;
+        $name = 'My Container';
+        $description = 'My container description';
+        $containerDao->createContainer($this->idSite, $idContainer, $context, $name, $description, $this->dateString);
+
+        // Create some versions to test with.
+        $versionDao = new ContainerVersionsDao();
+        $idDraftVersion = $versionDao->createDraftVersion($this->idSite, $idContainer, $this->dateString);
+
+        // Create some variables to test with.
+        $this->variableDao = new VariablesDao();
+        $idDraftVersionVariable = $this->createVariable($idDraftVersion);
+
+        $this->newVariableParameterMigrator->migrate();
+
+        $variable = $this->variableDao->getContainerVariable($this->idSite, $idDraftVersion, $idDraftVersionVariable);
+        $this->assertSame($idDraftVersionVariable, $variable['idvariable']);
+        $this->assertIsArray($variable);
+        $this->assertIsArray($variable['parameters']);
+        $this->assertCount(2, $variable['parameters']);
+        $this->assertArrayHasKey('cookieDomain', $variable['parameters']);
+        $this->assertSame('myNewValue', $variable['parameters']['cookieDomain']);
+        $this->assertNotEmpty($variable['description']);
+    }
+
+    public function test_migratingVariablesWithAdditionalField()
+    {
+        $this->newVariableParameterMigrator = new NewVariableParameterMigrator(MatomoConfigurationVariable::ID, 'cookieDomain', 'myNewValue');
+        $this->newVariableParameterMigrator->addField('cookiePath');
+        $this->newVariableParameterMigrator->addField('notValidTemplateProperty');
+        $this->dateString = '2015-01-01 01:02:03';
+
+        // Create some containers to test with.
+        $containerDao = new ContainersDao();
+        $this->idSite = 2;
+        $idContainer = 'abcdef';
+        $context = WebContext::ID;
+        $name = 'My Container';
+        $description = 'My container description';
+        $containerDao->createContainer($this->idSite, $idContainer, $context, $name, $description, $this->dateString);
+
+        // Create some versions to test with.
+        $versionDao = new ContainerVersionsDao();
+        $idDraftVersion = $versionDao->createDraftVersion($this->idSite, $idContainer, $this->dateString);
+
+        // Create some variables to test with.
+        $this->variableDao = new VariablesDao();
+        $idDraftVersionVariable = $this->createVariable($idDraftVersion);
+
+        $this->newVariableParameterMigrator->migrate();
+
+        $variable = $this->variableDao->getContainerVariable($this->idSite, $idDraftVersion, $idDraftVersionVariable);
+        $this->assertSame($idDraftVersionVariable, $variable['idvariable']);
+        $this->assertIsArray($variable);
+        $this->assertIsArray($variable['parameters']);
+        $this->assertCount(3, $variable['parameters']);
+        $this->assertArrayHasKey('cookieDomain', $variable['parameters']);
+        $this->assertSame('myNewValue', $variable['parameters']['cookieDomain']);
+        $this->assertArrayHasKey('cookiePath', $variable['parameters']);
+        $this->assertSame('', $variable['parameters']['cookiePath']);
+        $this->assertArrayNotHasKey('notValidTemplateProperty', $variable['parameters']);
+        $this->assertNotEmpty($variable['description']);
+    }
+
+}


### PR DESCRIPTION
### Description:

There were some cases where core tried to process the migration helper classes as migration files because they were in the Updates directory. This moves them to a different directory to avoid that. A regression with the variable migration helper was fixed as well.

TODO - This is a reminder to update 4.x-dev submodules after this is merged so that these changes will be in the next release. Also, merge this into 5.x-dev.

### Review

* [ ] [Functional review done](https://developer.matomo.org/guides/pull-request-reviews#functional-review-done)
* [ ] [Potential edge cases thought about](https://developer.matomo.org/guides/pull-request-reviews#potential-edge-cases-thought-about) (behavior of the code with strange input, with strange internal state or possible interactions with other Matomo subsystems)
* [ ] [Usability review done](https://developer.matomo.org/guides/pull-request-reviews#usability-review-done) (is anything maybe unclear or think about anything that would cause people to reach out to support)
* [ ] [Security review done](https://developer.matomo.org/guides/security-in-piwik#checklist)
* [ ] [Wording review done](https://developer.matomo.org/guides/pull-request-reviews#translations-wording-review-done)
* [ ] [Code review done](https://developer.matomo.org/guides/pull-request-reviews#code-review-done)
* [ ] [Tests were added if useful/possible](https://developer.matomo.org/guides/pull-request-reviews#tests-were-added-if-usefulpossible)
* [ ] [Reviewed for breaking changes](https://developer.matomo.org/guides/pull-request-reviews#reviewed-for-breaking-changes)
* [ ] [Developer changelog updated if needed](https://developer.matomo.org/guides/pull-request-reviews#developer-changelog-updated-if-needed)
* [ ] [Documentation added if needed](https://developer.matomo.org/guides/pull-request-reviews#documentation-added-if-needed)
* [ ] Existing documentation updated if needed
