### PR TITLE
Correctly mark tests that are not expected to perform assertions

### DIFF
--- a/tests/Integration/API/ImportTest.php
+++ b/tests/Integration/API/ImportTest.php
@@ -65,7 +65,8 @@ class ImportTest extends IntegrationTestCase
 
     public function test_checkImportContainerIsPossible_shouldWorkWhenUsingPreviousExport()
     {
-        self::expectNotToPerformAssertions();
+        // This test case actually doesn't have any assertions, but the fixture already performs some when it is set up.
+        // self::expectNotToPerformAssertions();
 
         $this->import->checkImportContainerIsPossible($this->exported, $this->idSite, $this->idContainer);
     }

--- a/tests/Integration/API/ImportTest.php
+++ b/tests/Integration/API/ImportTest.php
@@ -65,8 +65,9 @@ class ImportTest extends IntegrationTestCase
 
     public function test_checkImportContainerIsPossible_shouldWorkWhenUsingPreviousExport()
     {
+        self::expectNotToPerformAssertions();
+
         $this->import->checkImportContainerIsPossible($this->exported, $this->idSite, $this->idContainer);
-        $this->assertTrue(true);
     }
 
     public function test_checkImportContainerIsPossible_whenMissingTags()

--- a/tests/Integration/APITest.php
+++ b/tests/Integration/APITest.php
@@ -257,8 +257,9 @@ class APITest extends IntegrationTestCase
 
     public function test_deleteContainer_success()
     {
+        self::expectNotToPerformAssertions();
+
         $this->api->deleteContainer($this->idSite, $this->idContainer);
-        $this->assertTrue(true);
     }
 
     public function test_publishContainerVersion_shouldFailWhenNotHavingViewPermissions()
@@ -297,16 +298,18 @@ class APITest extends IntegrationTestCase
 
     public function test_publishContainerVersion_shouldSucceedForAdmin()
     {
+        self::expectNotToPerformAssertions();
+
         $this->api->publishContainerVersion($this->idSite, $this->idContainer, $this->idContainerDraftVersion, Environment::ENVIRONMENT_LIVE);
-        $this->assertTrue(true);
     }
 
     public function test_publishContainerVersion_shouldSucceedForPublishLiveCapability()
     {
+        self::expectNotToPerformAssertions();
+
         $this->setWriteUser();
         FakeAccess::$idSitesCapabilities = array(PublishLiveContainer::ID => array($this->idSite));
         $this->api->publishContainerVersion($this->idSite, $this->idContainer, $this->idContainerDraftVersion, Environment::ENVIRONMENT_LIVE);
-        $this->assertTrue(true);
     }
 
     public function test_addContainer_shouldFailWhenNotHavingViewPermissions()
@@ -969,10 +972,11 @@ class APITest extends IntegrationTestCase
 
     public function test_updateContainerVariable_successRegularTemplateWithWriteUser()
     {
+        self::expectNotToPerformAssertions();
+
         $id = $this->test_addContainerVariable_successRegularTemplateWithWriteUser();
 
         $this->api->updateContainerVariable($this->idSite, $this->idContainer, $this->idContainerDraftVersion, $id, 'myName2', array('urlPart' => 'href'));
-        $this->assertTrue(true);
     }
 
     public function test_updateContainerVariable_failMissingCustomTemplatePermission()
@@ -992,6 +996,8 @@ class APITest extends IntegrationTestCase
 
     public function test_updateContainerVariable_successWithCustomTemplatePermission()
     {
+        self::expectNotToPerformAssertions();
+
         $this->setAdminUser();
         $id = $this->api->addContainerVariable($this->idSite, $this->idContainer, $this->idContainerDraftVersion, CustomJsFunctionVariable::ID, 'myName');
 
@@ -999,7 +1005,6 @@ class APITest extends IntegrationTestCase
         FakeAccess::$idSitesCapabilities = array(UseCustomTemplates::ID => array($this->idSite));
 
         $this->api->updateContainerVariable($this->idSite, $this->idContainer, $this->idContainerDraftVersion, $id, 'myName2');
-        $this->assertTrue(true);
     }
 
     public function test_addContainerTag_successRegularTemplateWithWriteUser()
@@ -1014,6 +1019,8 @@ class APITest extends IntegrationTestCase
 
     public function test_updateContainerTag_successRegularTemplateWithWriteUser()
     {
+        self::expectNotToPerformAssertions();
+
         $id = $this->test_addContainerTag_successRegularTemplateWithWriteUser();
 
         $this->setWriteUser();
@@ -1021,7 +1028,6 @@ class APITest extends IntegrationTestCase
         $idTrigger = $this->test_addContainerTrigger_successRegularTemplateWithWriteUser($name = 'foobar');
         $fireTrigger = array($idTrigger);
         $this->api->updateContainerTag($this->idSite, $this->idContainer, $this->idContainerDraftVersion, $id, 'myName2', array('customImageSrc' => 'foo'), $fireTrigger);
-        $this->assertTrue(true);
     }
 
     public function test_updateContainerTag_failMissingCustomTemplatePermission()
@@ -1045,6 +1051,8 @@ class APITest extends IntegrationTestCase
 
     public function test_updateContainerTag_successWithCustomTemplatePermission()
     {
+        self::expectNotToPerformAssertions();
+
         $idTrigger = $this->test_addContainerTrigger_successRegularTemplateWithWriteUser();
         $this->setAdminUser();
 
@@ -1055,7 +1063,6 @@ class APITest extends IntegrationTestCase
         FakeAccess::$idSitesCapabilities = array(UseCustomTemplates::ID => array($this->idSite));
 
         $this->api->updateContainerTag($this->idSite, $this->idContainer, $this->idContainerDraftVersion, $id, 'myName2', array('customHtml' => 'foo'), $fireTrigger);
-        $this->assertTrue(true);
     }
 
     protected function setSuperUser()

--- a/tests/Integration/APITest.php
+++ b/tests/Integration/APITest.php
@@ -257,7 +257,8 @@ class APITest extends IntegrationTestCase
 
     public function test_deleteContainer_success()
     {
-        self::expectNotToPerformAssertions();
+        // This test case actually doesn't have any assertions, but the fixture already performs some when it is set up.
+        // self::expectNotToPerformAssertions();
 
         $this->api->deleteContainer($this->idSite, $this->idContainer);
     }
@@ -298,14 +299,16 @@ class APITest extends IntegrationTestCase
 
     public function test_publishContainerVersion_shouldSucceedForAdmin()
     {
-        self::expectNotToPerformAssertions();
+        // This test case actually doesn't have any assertions, but the fixture already performs some when it is set up.
+        // self::expectNotToPerformAssertions();
 
         $this->api->publishContainerVersion($this->idSite, $this->idContainer, $this->idContainerDraftVersion, Environment::ENVIRONMENT_LIVE);
     }
 
     public function test_publishContainerVersion_shouldSucceedForPublishLiveCapability()
     {
-        self::expectNotToPerformAssertions();
+        // This test case actually doesn't have any assertions, but the fixture already performs some when it is set up.
+        // self::expectNotToPerformAssertions();
 
         $this->setWriteUser();
         FakeAccess::$idSitesCapabilities = array(PublishLiveContainer::ID => array($this->idSite));
@@ -972,8 +975,6 @@ class APITest extends IntegrationTestCase
 
     public function test_updateContainerVariable_successRegularTemplateWithWriteUser()
     {
-        self::expectNotToPerformAssertions();
-
         $id = $this->test_addContainerVariable_successRegularTemplateWithWriteUser();
 
         $this->api->updateContainerVariable($this->idSite, $this->idContainer, $this->idContainerDraftVersion, $id, 'myName2', array('urlPart' => 'href'));
@@ -996,7 +997,8 @@ class APITest extends IntegrationTestCase
 
     public function test_updateContainerVariable_successWithCustomTemplatePermission()
     {
-        self::expectNotToPerformAssertions();
+        // This test case actually doesn't have any assertions, but the fixture already performs some when it is set up.
+        // self::expectNotToPerformAssertions();
 
         $this->setAdminUser();
         $id = $this->api->addContainerVariable($this->idSite, $this->idContainer, $this->idContainerDraftVersion, CustomJsFunctionVariable::ID, 'myName');
@@ -1019,8 +1021,6 @@ class APITest extends IntegrationTestCase
 
     public function test_updateContainerTag_successRegularTemplateWithWriteUser()
     {
-        self::expectNotToPerformAssertions();
-
         $id = $this->test_addContainerTag_successRegularTemplateWithWriteUser();
 
         $this->setWriteUser();
@@ -1051,8 +1051,6 @@ class APITest extends IntegrationTestCase
 
     public function test_updateContainerTag_successWithCustomTemplatePermission()
     {
-        self::expectNotToPerformAssertions();
-
         $idTrigger = $this->test_addContainerTrigger_successRegularTemplateWithWriteUser();
         $this->setAdminUser();
 

--- a/tests/Integration/Dao/ContainerReleaseDaoTest.php
+++ b/tests/Integration/Dao/ContainerReleaseDaoTest.php
@@ -381,8 +381,9 @@ class ContainerReleaseDaoTest extends IntegrationTestCase
 
     public function test_deleteAllVersionsForRelease_givenSiteHasNoReleases_shouldNotFail()
     {
+        self::expectNotToPerformAssertions();
+
         $this->dao->deleteAllVersionsForRelease($idSite = 3, 'abcdee', 'live', $this->now);
-        $this->assertTrue(true);
     }
 
     public function test_deleteAllVersionsForRelease_shouldOnlyDeleteReleasesThatBelongToGivenSite()

--- a/tests/Integration/Dao/ContainerVersionsDaoTest.php
+++ b/tests/Integration/Dao/ContainerVersionsDaoTest.php
@@ -268,11 +268,11 @@ class ContainerVersionsDaoTest extends IntegrationTestCase
 
     public function test_updateVersionColumns_doesNotFailWhenNoColumsAreToBeUpdated()
     {
+        self::expectNotToPerformAssertions();
+
         $idVersion = $this->createVersion($idSite = 3);
 
         $this->dao->updateContainerColumns($idSite, $idContainerVersion = 5, $idVersion, array());
-
-        $this->assertTrue(true);
     }
 
     public function test_updateVersionColumns_updatesASingleColumn()

--- a/tests/Integration/Dao/ContainersDaoTest.php
+++ b/tests/Integration/Dao/ContainersDaoTest.php
@@ -186,6 +186,8 @@ class ContainersDaoTest extends IntegrationTestCase
 
     public function test_updateContainer_succeedsToSetSameNameThatIsUsedAlreadyByThisContainer()
     {
+        self::expectNotToPerformAssertions();
+
         $idSite = 3;
         $idContainer = 'abcdef';
         $name = 'myname2';
@@ -200,11 +202,11 @@ class ContainersDaoTest extends IntegrationTestCase
 
     public function test_updateContainerColumns_doesNotFailWhenNoColumsAreToBeUpdated()
     {
+        self::expectNotToPerformAssertions();
+
         $idContainer = $this->createContainer($idSite = 3);
 
         $this->dao->updateContainerColumns($idSite, $idContainer, array());
-
-        $this->assertTrue(true);
     }
 
     public function test_updateContainerColumns_updatesASingleColumn()

--- a/tests/Integration/Dao/TagsDaoTest.php
+++ b/tests/Integration/Dao/TagsDaoTest.php
@@ -270,11 +270,11 @@ class TagsDaoTest extends IntegrationTestCase
 
     public function test_updateTagColumns_doesNotFailWhenNoColumsAreToBeUpdated()
     {
+        self::expectNotToPerformAssertions();
+
         $idTag = $this->createTag($idSite = 3);
 
         $this->dao->updateTagColumns($idSite, $idContainerVersion = 5, $idTag, array());
-
-        $this->assertTrue(true);
     }
 
     public function test_updateTagColumns_updatesASingleColumn()

--- a/tests/Integration/Dao/TriggersDaoTest.php
+++ b/tests/Integration/Dao/TriggersDaoTest.php
@@ -248,11 +248,11 @@ class TriggersDaoTest extends IntegrationTestCase
 
     public function test_updateTriggerColumns_doesNotFailWhenNoColumsAreToBeUpdated()
     {
+        self::expectNotToPerformAssertions();
+
         $idTrigger = $this->createTrigger($idSite = 3);
 
         $this->dao->updateTriggerColumns($idSite, $idContainerVersion = 5, $idTrigger, array());
-
-        $this->assertTrue(true);
     }
 
     public function test_updateTriggerColumns_updatesASingleColumn()

--- a/tests/Integration/Dao/VariablesDaoTest.php
+++ b/tests/Integration/Dao/VariablesDaoTest.php
@@ -252,11 +252,11 @@ class VariablesDaoTest extends IntegrationTestCase
 
     public function test_updateVariableColumns_doesNotFailWhenNoColumsAreToBeUpdated()
     {
+        self::expectNotToPerformAssertions();
+
         $idVariable = $this->createVariable($idSite = 3);
 
         $this->dao->updateVariableColumns($idSite, $idContainerVersion = 5, $idVariable, array());
-
-        $this->assertTrue(true);
     }
 
     public function test_updateVariableColumns_updatesASingleColumn()

--- a/tests/Integration/Input/AccessValidatorTest.php
+++ b/tests/Integration/Input/AccessValidatorTest.php
@@ -55,30 +55,34 @@ class AccessValidatorTest extends IntegrationTestCase
 
     public function test_checkWriteCapability_successWrite()
     {
+        self::expectNotToPerformAssertions();
+
         $this->setWrite();
         $this->validator->checkWriteCapability($idSite = 1);
-        $this->assertTrue(true);
     }
 
     public function test_checkWriteCapability_successAdmin()
     {
+        self::expectNotToPerformAssertions();
+
         $this->setAdmin();
         $this->validator->checkWriteCapability($idSite = 1);
-        $this->assertTrue(true);
     }
 
     public function test_checkWriteCapability_successSuperUser()
     {
+        self::expectNotToPerformAssertions();
+
         $this->validator->checkWriteCapability($idSite = 1);
-        $this->assertTrue(true);
     }
 
     public function test_checkWriteCapability_successViewUserWithCapability()
     {
+        self::expectNotToPerformAssertions();
+
         $this->setUser();
         FakeAccess::$idSitesCapabilities = array(TagManagerWrite::ID => array($idSite = 1));
         $this->validator->checkWriteCapability($idSite = 1);
-        $this->assertTrue(true);
     }
 
     public function test_checkPublishLiveEnvironmentCapability()
@@ -92,23 +96,26 @@ class AccessValidatorTest extends IntegrationTestCase
 
     public function test_checkPublishLiveEnvironmentCapability_successAdmin()
     {
+        self::expectNotToPerformAssertions();
+
         $this->setAdmin();
         $this->validator->checkPublishLiveEnvironmentCapability($idSite = 1);
-        $this->assertTrue(true);
     }
 
     public function test_checkPublishLiveEnvironmentCapability_successWriteUserWithCapability()
     {
+        self::expectNotToPerformAssertions();
+
         $this->setUser();
         FakeAccess::$idSitesCapabilities = array(PublishLiveContainer::ID => array($idSite = 1));
         $this->validator->checkPublishLiveEnvironmentCapability($idSite = 1);
-        $this->assertTrue(true);
     }
 
     public function test_checkPublishLiveEnvironmentCapability_successSuperUser()
     {
+        self::expectNotToPerformAssertions();
+
         $this->validator->checkPublishLiveEnvironmentCapability($idSite = 1);
-        $this->assertTrue(true);
     }
 
     public function test_hasUseCustomTemplatesCapability()
@@ -154,15 +161,17 @@ class AccessValidatorTest extends IntegrationTestCase
 
     public function test_checkUseCustomTemplatesCapability_successAdmin()
     {
+        self::expectNotToPerformAssertions();
+
         $this->setAdmin();
         $this->validator->checkUseCustomTemplatesCapability($idSite = 1);
-        $this->assertTrue(true);
     }
 
     public function test_checkUseCustomTemplatesCapability_successSuperUser()
     {
+        self::expectNotToPerformAssertions();
+
         $this->validator->checkUseCustomTemplatesCapability($idSite = 1);
-        $this->assertTrue(true);
     }
 
     public function test_checkViewPermission()
@@ -176,15 +185,17 @@ class AccessValidatorTest extends IntegrationTestCase
 
     public function test_checkViewPermission_success()
     {
+        self::expectNotToPerformAssertions();
+
         $this->setUser();
         $this->validator->checkViewPermission($idSite = 1);
-        $this->assertTrue(true);
     }
 
     public function test_checkSiteExists_whenSiteExists_noException()
     {
+        self::expectNotToPerformAssertions();
+
         $this->validator->checkSiteExists($idSite = 1);
-        $this->assertTrue(true);
     }
 
     public function test_checkSiteExists_whenSiteNotExists_Exception()

--- a/tests/Integration/Input/IdSiteTest.php
+++ b/tests/Integration/Input/IdSiteTest.php
@@ -30,6 +30,8 @@ class IdSiteTest extends IntegrationTestCase
 
     public function test_validate_successValueNotEmpty()
     {
+        self::expectNotToPerformAssertions();
+
         $this->checkIdSite('1');
         $this->checkIdSite('2');
         $this->checkIdSite(1);

--- a/tests/Integration/Model/ContainerTest.php
+++ b/tests/Integration/Model/ContainerTest.php
@@ -241,8 +241,9 @@ class ContainerTest extends IntegrationTestCase
 
     public function test_checkContainerExists_noExceptionWhenExists()
     {
+        self::expectNotToPerformAssertions();
+
         $this->model->checkContainerExists($this->idSite, $this->idContainer1);
-        $this->assertTrue(true);
     }
 
     public function test_getContainer()
@@ -883,10 +884,11 @@ class ContainerTest extends IntegrationTestCase
 
     public function test_checkContainerReleaseExists_whenReleaseExistsNoException()
     {
+        self::expectNotToPerformAssertions();
+
         $this->publishVersion($this->idSite, $this->idContainer1, $this->idContainer1draft, Environment::ENVIRONMENT_LIVE);
 
         $this->model->checkContainerReleaseExists($this->idSite, $this->idContainer1, Environment::ENVIRONMENT_LIVE);
-        $this->assertTrue(true);
     }
 
     public function test_getContainerInstallInstructions_checksEnvironmentExists()

--- a/tests/Integration/Model/EnvironmentTest.php
+++ b/tests/Integration/Model/EnvironmentTest.php
@@ -49,6 +49,8 @@ class EnvironmentTest extends IntegrationTestCase
 
     public function test_checkEnvironmentNameFormat_valid()
     {
+        self::expectNotToPerformAssertions();
+
         Environment::checkEnvironmentNameFormat('fo_f');
         Environment::checkEnvironmentNameFormat('foo_f');
         Environment::checkEnvironmentNameFormat('fo');
@@ -59,7 +61,6 @@ class EnvironmentTest extends IntegrationTestCase
         Environment::checkEnvironmentNameFormat('foo9');
         Environment::checkEnvironmentNameFormat('949101');
         Environment::checkEnvironmentNameFormat('949_101');
-        $this->assertTrue(true);
     }
 
     public function test_checkEnvironmentNameFormat_tooLong()
@@ -112,9 +113,10 @@ class EnvironmentTest extends IntegrationTestCase
 
     public function test_checkIsValidEnvironment_valid()
     {
+        self::expectNotToPerformAssertions();
+
         $this->environment->checkIsValidEnvironment(Environment::ENVIRONMENT_LIVE);
         $this->environment->checkIsValidEnvironment('dev'); // selected by default
-        $this->assertTrue(true);
     }
 
     public function test_getEnvironments()

--- a/tests/Integration/SystemSettingTest.php
+++ b/tests/Integration/SystemSettingTest.php
@@ -137,13 +137,14 @@ class SystemSettingTest extends IntegrationTestCase
 
     public function test_save_willNotFail()
     {
+        self::expectNotToPerformAssertions();
+
         $this->settings->save();
         $this->settings->environments->setValue(array(
             array('environment' => 'BaZ'),
             array('environment' => 'fOo'),
         ));
         $this->settings->save();
-        $this->assertTrue(true);
     }
 
 }

--- a/tests/Integration/Template/Tag/TagsProviderTest.php
+++ b/tests/Integration/Template/Tag/TagsProviderTest.php
@@ -65,8 +65,9 @@ class TagsProviderTest extends IntegrationTestCase
 
     public function test_checkIsValidTag_noExceptionWhenTagExists()
     {
+        self::expectNotToPerformAssertions();
+
         $this->provider->checkIsValidTag('Matomo');
-        $this->assertTrue(true);
     }
 
     public function test_checkIsValidTag_searchesCaseSensitive()

--- a/tests/Integration/Template/Trigger/TriggersProviderTest.php
+++ b/tests/Integration/Template/Trigger/TriggersProviderTest.php
@@ -65,8 +65,9 @@ class TriggersProviderTest extends IntegrationTestCase
 
     public function test_checkIsValidTrigger_noExceptionWhenTriggerExists()
     {
+        self::expectNotToPerformAssertions();
+
         $this->provider->checkIsValidTrigger('DomReady');
-        $this->assertTrue(true);
     }
 
     public function test_checkIsValidTrigger_searchesCaseSensitive()

--- a/tests/Integration/Template/Variable/VariablesProviderTest.php
+++ b/tests/Integration/Template/Variable/VariablesProviderTest.php
@@ -125,8 +125,9 @@ class VariablesProviderTest extends IntegrationTestCase
 
     public function test_checkIsValidVariable_noExceptionWhenVariableExists()
     {
+        self::expectNotToPerformAssertions();
+
         $this->provider->checkIsValidVariable('DataLayer');
-        $this->assertTrue(true);
     }
 
     public function test_checkIsValidVariable_searchesCaseSensitive()

--- a/tests/Integration/UpdateHelper/NewVariableParameterMigratorTest.php
+++ b/tests/Integration/UpdateHelper/NewVariableParameterMigratorTest.php
@@ -44,8 +44,8 @@ class NewVariableParameterMigratorTest extends IntegrationTestCase
     {
         parent::setUp();
 
-        $this->tagFixture = new TagManagerFixture();
-        $this->tagFixture->setUpWebsite();
+        $tagFixture = new TagManagerFixture();
+        $tagFixture->setUpWebsite();
 
         $this->newVariableParameterMigrator = new NewVariableParameterMigrator(MatomoConfigurationVariable::ID, 'cookieDomain');
     }

--- a/tests/Integration/Validators/TriggerConditionsTest.php
+++ b/tests/Integration/Validators/TriggerConditionsTest.php
@@ -123,6 +123,8 @@ class TriggerConditionsTest extends IntegrationTestCase
 
     public function test_valid_preconfiguredVariable()
     {
+        self::expectNotToPerformAssertions();
+
         $this->validateTriggerIds($this->idSite, $containerVersion = 5, array(
             ['actual' => ErrorUrlVariable::ID, 'comparison' => 'equals', 'expected' => 'foo'],
         ));
@@ -130,6 +132,8 @@ class TriggerConditionsTest extends IntegrationTestCase
 
     public function test_valid_customVariable()
     {
+        self::expectNotToPerformAssertions();
+
         $this->validateTriggerIds($this->idSite, $containerVersion = 5, array(
             ['actual' => 'myVar1', 'comparison' => 'equals', 'expected' => 'foo'],
         ));
@@ -137,6 +141,8 @@ class TriggerConditionsTest extends IntegrationTestCase
 
     public function test_valid_mixed()
     {
+        self::expectNotToPerformAssertions();
+
         $this->validateTriggerIds($this->idSite, $containerVersion = 5, array(
             ['actual' => 'myVar1', 'comparison' => 'equals', 'expected' => 'foo'],
             ['actual' => ErrorUrlVariable::ID, 'comparison' => 'equals', 'expected' => 'foobar'],
@@ -145,6 +151,8 @@ class TriggerConditionsTest extends IntegrationTestCase
 
     public function test_valid_empty()
     {
+        self::expectNotToPerformAssertions();
+
         $this->validateTriggerIds($this->idSite, $containerVersion = 5, array());
     }
 

--- a/tests/Integration/Validators/TriggerIdsTest.php
+++ b/tests/Integration/Validators/TriggerIdsTest.php
@@ -58,6 +58,8 @@ class TriggerIdsTest extends IntegrationTestCase
 
     public function test_valid_empty()
     {
+        self::expectNotToPerformAssertions();
+
         $this->validateTriggerIds($this->idSite, $containerVersion = 5, array());
     }
 

--- a/tests/Integration/Validators/TriggerIdsTest.php
+++ b/tests/Integration/Validators/TriggerIdsTest.php
@@ -51,6 +51,8 @@ class TriggerIdsTest extends IntegrationTestCase
 
     public function test_valid()
     {
+        self::expectNotToPerformAssertions();
+
         $this->validateTriggerIds($this->idSite, $containerVersion = 5, array(1,3));
         $this->validateTriggerIds($this->idSite, $containerVersion = 6, array(2));
         $this->validateTriggerIds($this->idSite, $containerVersion = 5, array(1));

--- a/tests/Unit/Input/DescriptionTest.php
+++ b/tests/Unit/Input/DescriptionTest.php
@@ -28,13 +28,14 @@ class DescriptionTest extends UnitTestCase
 
     public function test_check_valid()
     {
+        self::expectNotToPerformAssertions();
+
         $this->checkDescription(false);
         $this->checkDescription('');
         $this->checkDescription('s');
         $this->checkDescription(str_pad('2', Description::MAX_LENGTH - 1, 'f'));
         $this->checkDescription('fooBarBaz4392');
         $this->checkDescription('foo Bar Baz 4392');
-        $this->assertTrue(true);
     }
 
     private function checkDescription($description)

--- a/tests/Unit/Input/NameTest.php
+++ b/tests/Unit/Input/NameTest.php
@@ -45,6 +45,8 @@ class NameTest extends UnitTestCase
 
     public function test_check_valid()
     {
+        self::expectNotToPerformAssertions();
+
         $this->checkName('s');
         $this->checkName(str_pad('2', Name::MAX_LENGTH - 1, 'f'));
         $this->checkName('fooBarBaz4392');
@@ -52,7 +54,6 @@ class NameTest extends UnitTestCase
         $this->checkName('121 212 12f');
         $this->checkName('f1212121212');
         $this->checkName('fooBarBaz4392');
-        $this->assertTrue(true);
     }
 
     private function checkName($name)

--- a/tests/Unit/Model/ComparisonsTest.php
+++ b/tests/Unit/Model/ComparisonsTest.php
@@ -32,11 +32,11 @@ class ComparisonsTest extends UnitTestCase
 
     public function test_checkIsValidComparison_valid()
     {
+        self::expectNotToPerformAssertions();
+
         $this->checkIsValidComparison('equals');
         $this->checkIsValidComparison('not_equals');
         $this->checkIsValidComparison('starts_with');
-
-        self::assertTrue(true);
     }
 
     public function test_checkIsValidComparison_hasToMatchExact()

--- a/tests/Unit/Validators/LookupTableTest.php
+++ b/tests/Unit/Validators/LookupTableTest.php
@@ -80,6 +80,8 @@ class LookupTableTest extends UnitTestCase
 
     public function test_valid()
     {
+        self::expectNotToPerformAssertions();
+
         $this->validateLookupTable(array(array('match_value' => 'foo', 'comparison' => 'equals', 'out_value' => 'bar')));
         $this->validateLookupTable(array(array('match_value' => '', 'comparison' => 'equals', 'out_value' => 'bar')));
         $this->validateLookupTable(array(array('match_value' => '0', 'comparison' => 'equals', 'out_value' => 'bar')));
@@ -88,15 +90,13 @@ class LookupTableTest extends UnitTestCase
             array('match_value' => 'bar', 'comparison' => 'starts_with', 'out_value' => 'baz'),
             array('match_value' => 'baz', 'comparison' => 'not_equals', 'out_value' => 'bar'),
         ));
-
-        self::assertTrue(true);
     }
 
     public function test_valid_empty()
     {
-        $this->validateLookupTable(array());
+        self::expectNotToPerformAssertions();
 
-        self::assertTrue(true);
+        $this->validateLookupTable(array());
     }
 
     private function validateLookupTable($value)

--- a/tests/Unit/Validators/NumericTest.php
+++ b/tests/Unit/Validators/NumericTest.php
@@ -46,16 +46,16 @@ class NumericTest extends UnitTestCase
 
     public function test_numeric()
     {
-        $this->validateNumeric('2430.00');
+        self::expectNotToPerformAssertions();
 
-        self::assertTrue(true);
+        $this->validateNumeric('2430.00');
     }
 
     public function test_emptyOptional()
     {
-        $this->validateNumeric('', true);
+        self::expectNotToPerformAssertions();
 
-        self::assertTrue(true);
+        $this->validateNumeric('', true);
     }
 
     public function test_emptyNotOptional()
@@ -84,9 +84,9 @@ class NumericTest extends UnitTestCase
 
     public function test_variableAllowed()
     {
-        $this->validateNumeric('{{someVariable}}', true, true);
+        self::expectNotToPerformAssertions();
 
-        self::assertTrue(true);
+        $this->validateNumeric('{{someVariable}}', true, true);
     }
 
     private function validateNumeric($value, $isOptional = null, $isVariableAllowed = null)


### PR DESCRIPTION
### Description:

Running tests throwed a couple of warnings for tests that don't perform any assertions.
This is kind of expected for a couple of tests and while looking into it, it seems that for a lot tests such warning was suppressed by adding a `assertTrue(true)`.

That is actually not the correct way to handle tests without (useful) assertions. PHPUnit has a special method for that `expectNotToPerformAssertions`.

I've added that to all the tests that only compare true with true or didn't have any assertions at all.

### Review

* [ ] [Functional review done](https://developer.matomo.org/guides/pull-request-reviews#functional-review-done)
* [ ] [Potential edge cases thought about](https://developer.matomo.org/guides/pull-request-reviews#potential-edge-cases-thought-about) (behavior of the code with strange input, with strange internal state or possible interactions with other Matomo subsystems)
* [ ] [Usability review done](https://developer.matomo.org/guides/pull-request-reviews#usability-review-done) (is anything maybe unclear or think about anything that would cause people to reach out to support)
* [ ] [Security review done](https://developer.matomo.org/guides/security-in-piwik#checklist)
* [ ] [Wording review done](https://developer.matomo.org/guides/pull-request-reviews#translations-wording-review-done)
* [ ] [Code review done](https://developer.matomo.org/guides/pull-request-reviews#code-review-done)
* [ ] [Tests were added if useful/possible](https://developer.matomo.org/guides/pull-request-reviews#tests-were-added-if-usefulpossible)
* [ ] [Reviewed for breaking changes](https://developer.matomo.org/guides/pull-request-reviews#reviewed-for-breaking-changes)
* [ ] [Developer changelog updated if needed](https://developer.matomo.org/guides/pull-request-reviews#developer-changelog-updated-if-needed)
* [ ] [Documentation added if needed](https://developer.matomo.org/guides/pull-request-reviews#documentation-added-if-needed)
* [ ] Existing documentation updated if needed
