### PR TITLE
Update EtrackerTag.web.js - Added custom dimension for SPA

### DIFF
--- a/Template/Tag/EtrackerTag.web.js
+++ b/Template/Tag/EtrackerTag.web.js
@@ -75,6 +75,18 @@
             if(parameters.get('etrackerWrapperBasket')){
                ewrapper.et_basket = parameters.get('etrackerWrapperBasket');
             }
+            // Custom Dimensions
+            if (etrackerConfig.customDimensions
+                && TagManager.utils.isArray(etrackerConfig.customDimensions)
+                && etrackerConfig.customDimensions.length) {
+                var dimIndex;
+                for (dimIndex = 0; dimIndex < etrackerConfig.customDimensions.length; dimIndex++) {
+                    var dimension = etrackerConfig.customDimensions[dimIndex];
+                    if (dimension && TagManager.utils.isObject(dimension) && dimension.index && dimension.value) {
+                        ewrapper[dimension.index] = dimension.value;
+                    }
+                }
+            }
             et_eC_Wrapper(ewrapper);
         }
         // event tracking function


### PR DESCRIPTION
### Description:

Added custom dimension for wrapper requests as the requests were not updated by the current values. This is needed for SPA.

### Review

* [x] [Functional review done](https://developer.matomo.org/guides/pull-request-reviews#functional-review-done)
* [x] [Potential edge cases thought about](https://developer.matomo.org/guides/pull-request-reviews#potential-edge-cases-thought-about) (behavior of the code with strange input, with strange internal state or possible interactions with other Matomo subsystems)
* [ ] [Usability review done](https://developer.matomo.org/guides/pull-request-reviews#usability-review-done) (is anything maybe unclear or think about anything that would cause people to reach out to support)
* [ ] [Security review done](https://developer.matomo.org/guides/security-in-piwik#checklist)
* [ ] [Wording review done](https://developer.matomo.org/guides/pull-request-reviews#translations-wording-review-done)
* [ ] [Code review done](https://developer.matomo.org/guides/pull-request-reviews#code-review-done)
* [ ] [Tests were added if useful/possible](https://developer.matomo.org/guides/pull-request-reviews#tests-were-added-if-usefulpossible)
* [ ] [Reviewed for breaking changes](https://developer.matomo.org/guides/pull-request-reviews#reviewed-for-breaking-changes)
* [ ] [Developer changelog updated if needed](https://developer.matomo.org/guides/pull-request-reviews#developer-changelog-updated-if-needed)
* [ ] [Documentation added if needed](https://developer.matomo.org/guides/pull-request-reviews#documentation-added-if-needed)
* [ ] Existing documentation updated if needed
