### PR TITLE
Fix issue with publish new version link

### DIFF
--- a/javascripts/tagmanagerHelper.js
+++ b/javascripts/tagmanagerHelper.js
@@ -41,7 +41,7 @@
 
     tagManagerHelper.createNewVersion = function () {
         var containerId = CoreHome.MatomoUrl.parsed.value.idContainer;
-        this.editVersion(null, containerId, 0, function () { window.location.reload(); });
+        this.editVersion(containerId, 0, function () { window.location.reload(); });
     };
     tagManagerHelper.editVersion = function (idContainer, idContainerVersion, callback) {
       var createVNode = Vue.createVNode;

--- a/tests/UI/ContainerVariable_spec.js
+++ b/tests/UI/ContainerVariable_spec.js
@@ -224,7 +224,6 @@ describe("ContainerVariable", function () {
         await page.waitForNetworkIdle();
         await page.click('div.notification-body a.createNewVersionLink');
         await page.waitForNetworkIdle();
-        await page.waitForTimeout(1000);
         await capture.selector(page, 'create_version_after_update', 'div.modal div.modal-content');
     });
 

--- a/tests/UI/ContainerVariable_spec.js
+++ b/tests/UI/ContainerVariable_spec.js
@@ -217,6 +217,17 @@ describe("ContainerVariable", function () {
         await captureCustomVariablesList('create_advanced_verified');
     });
 
+    it('should be possible to create a new version after updating a variable', async function () {
+        await page.click('tbody tr:last-of-type td.action a.icon-edit');
+        await page.waitForNetworkIdle();
+        await page.click('div.matomo-save-button');
+        await page.waitForNetworkIdle();
+        await page.click('div.notification-body a.createNewVersionLink');
+        await page.waitForNetworkIdle();
+        await page.waitForTimeout(1000);
+        await capture.selector(page, 'create_version_after_update', 'div.modal div.modal-content');
+    });
+
     it('should load variables page with some variables as view user', async function () {
         permissions.setViewUser();
         await page.goto(container1Base);

--- a/tests/UI/expected-screenshots/ContainerVariable_create_version_after_update.png
+++ b/tests/UI/expected-screenshots/ContainerVariable_create_version_after_update.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:303b8c3e16a9c64f6d80fb8354c5a939998788e44aa4c529f28d93eb9fb98260
+size 128715


### PR DESCRIPTION
### Description:

Fix issue with publish new version link. After creating/updating a tag/variable/trigger, a link is displayed as part of the notification. This link isn't including the container ID in the request, which causes an error to be displayed. This ticket fixes the ID not being included in the request. It also adds a UI test case to confirm that the error is no longer displayed.

Jira issue: PG-3219
Fixes: #740

### Review

* [ ] [Functional review done](https://developer.matomo.org/guides/pull-request-reviews#functional-review-done)
* [ ] [Potential edge cases thought about](https://developer.matomo.org/guides/pull-request-reviews#potential-edge-cases-thought-about) (behavior of the code with strange input, with strange internal state or possible interactions with other Matomo subsystems)
* [ ] [Usability review done](https://developer.matomo.org/guides/pull-request-reviews#usability-review-done) (is anything maybe unclear or think about anything that would cause people to reach out to support)
* [ ] [Security review done](https://developer.matomo.org/guides/security-in-piwik#checklist)
* [ ] [Wording review done](https://developer.matomo.org/guides/pull-request-reviews#translations-wording-review-done)
* [ ] [Code review done](https://developer.matomo.org/guides/pull-request-reviews#code-review-done)
* [ ] [Tests were added if useful/possible](https://developer.matomo.org/guides/pull-request-reviews#tests-were-added-if-usefulpossible)
* [ ] [Reviewed for breaking changes](https://developer.matomo.org/guides/pull-request-reviews#reviewed-for-breaking-changes)
* [ ] [Developer changelog updated if needed](https://developer.matomo.org/guides/pull-request-reviews#developer-changelog-updated-if-needed)
* [ ] [Documentation added if needed](https://developer.matomo.org/guides/pull-request-reviews#documentation-added-if-needed)
* [ ] Existing documentation updated if needed
