### PR TITLE
Automatically delete containers for non existing sites

### DIFF
--- a/Tasks.php
+++ b/Tasks.php
@@ -8,6 +8,9 @@
 namespace Piwik\Plugins\TagManager;
 
 use Piwik\Plugin;
+use Piwik\Plugins\TagManager\Dao\ContainersDao;
+use Piwik\Site;
+use Piwik\Exception\UnexpectedWebsiteFoundException;
 
 class Tasks extends \Piwik\Plugin\Tasks
 {
@@ -24,6 +27,7 @@ class Tasks extends \Piwik\Plugin\Tasks
     public function schedule()
     {
         $this->hourly('regenerateReleasedContainers');
+        $this->daily('deleteContainersForNonExistingSite');
     }
 
     public function regenerateReleasedContainers()
@@ -32,6 +36,44 @@ class Tasks extends \Piwik\Plugin\Tasks
         $tagManager = $this->pluginManager->getLoadedPlugin('TagManager');
         if ($tagManager) {
             $tagManager->regenerateReleasedContainers();
+        }
+    }
+
+    public function deleteContainersForNonExistingSite()
+    {
+        /** @var TagManager $tagManager */
+        $tagManager = $this->pluginManager->getLoadedPlugin('TagManager');
+        if (!$tagManager) {
+            return;
+        }
+        $containerDao = new ContainersDao();
+        $containers = $containerDao->getAllContainers();
+        $siteIdsDeleted = [];
+        foreach ($containers as $container) {
+            $idsite = $container['idsite'];
+            if ($idsite === 286) {
+                $a=1;
+            }
+            if (!isset($siteIdsDeleted[$idsite]) && !$this->siteExists($idsite)) {
+                $siteIdsDeleted[$idsite] = $idsite;
+            }
+        }
+
+        if (!empty($siteIdsDeleted)) {
+            $tagManager = new TagManager();
+            foreach ($siteIdsDeleted as $siteId) {
+                $tagManager->onSiteDeleted($siteId);
+            }
+        }
+    }
+
+    private function siteExists($idSite)
+    {
+        try {
+            new Site($idSite);
+            return true;
+        } catch (UnexpectedWebsiteFoundException $ex) {
+            return false;
         }
     }
 }

--- a/Tasks.php
+++ b/Tasks.php
@@ -47,15 +47,12 @@ class Tasks extends \Piwik\Plugin\Tasks
             return;
         }
         $containerDao = new ContainersDao();
-        $containers = $containerDao->getAllContainers();
+        $containers = $containerDao->getActiveContainersInfo();
         $siteIdsDeleted = [];
         foreach ($containers as $container) {
-            $idsite = $container['idsite'];
-            if ($idsite === 286) {
-                $a=1;
-            }
-            if (!isset($siteIdsDeleted[$idsite]) && !$this->siteExists($idsite)) {
-                $siteIdsDeleted[$idsite] = $idsite;
+            $idSite = $container['idsite'];
+            if (!isset($siteIdsDeleted[$idSite]) && !$this->siteExists($idSite)) {
+                $siteIdsDeleted[$idSite] = $idSite;
             }
         }
 


### PR DESCRIPTION
### Description:

Added code to delete containers for non existing site
Fixes: #PG-2573

To test you can run this command `./console scheduled-tasks:run --force "Piwik\Plugins\TagManager\Tasks.deleteContainersForNonExistingSite"`

### Review

* [ ] [Functional review done](https://developer.matomo.org/guides/pull-request-reviews#functional-review-done)
* [ ] [Potential edge cases thought about](https://developer.matomo.org/guides/pull-request-reviews#potential-edge-cases-thought-about) (behavior of the code with strange input, with strange internal state or possible interactions with other Matomo subsystems)
* [ ] [Usability review done](https://developer.matomo.org/guides/pull-request-reviews#usability-review-done) (is anything maybe unclear or think about anything that would cause people to reach out to support)
* [ ] [Security review done](https://developer.matomo.org/guides/security-in-piwik#checklist)
* [ ] [Wording review done](https://developer.matomo.org/guides/pull-request-reviews#translations-wording-review-done)
* [ ] [Code review done](https://developer.matomo.org/guides/pull-request-reviews#code-review-done)
* [ ] [Tests were added if useful/possible](https://developer.matomo.org/guides/pull-request-reviews#tests-were-added-if-usefulpossible)
* [ ] [Reviewed for breaking changes](https://developer.matomo.org/guides/pull-request-reviews#reviewed-for-breaking-changes)
* [ ] [Developer changelog updated if needed](https://developer.matomo.org/guides/pull-request-reviews#developer-changelog-updated-if-needed)
* [ ] [Documentation added if needed](https://developer.matomo.org/guides/pull-request-reviews#documentation-added-if-needed)
* [ ] Existing documentation updated if needed
