### PR TITLE
Added code to flush localPaq if no callback set but trackPageView set, #PG-3463

### DIFF
--- a/Template/Tag/MatomoTag.web.js
+++ b/Template/Tag/MatomoTag.web.js
@@ -22,15 +22,13 @@
     var localPaq = window._paq && window._paq.length ? JSON.parse(JSON.stringify(window._paq)) : localPaq || [];
     var indexesOfConfigs = [];
     var hasTrackPageViewViaPaq = false;
-    var j = -1;
     // Clear window._paq to prevent things from being tracked too early
     while (window._paq.length > 0) {
-        j++;
+        var poppedItem = window._paq.pop();
         // Check if trackPageView is set in _paq variable to ensure tracking works even with no callback
-        if (Array.isArray(window._paq[j]) && window._paq[j].toString() == ['trackPageView'].toString()) {
+        if (Array.isArray(poppedItem) && poppedItem.toString() == ['trackPageView'].toString()) {
             hasTrackPageViewViaPaqIndex = true;
         }
-        window._paq.pop();
     }
 
     var hasProcessedRemainingTrackings = false;

--- a/Template/Tag/MatomoTag.web.js
+++ b/Template/Tag/MatomoTag.web.js
@@ -27,7 +27,7 @@
         var poppedItem = window._paq.pop();
         // Check if trackPageView is set in _paq variable to ensure tracking works even with no callback
         if (Array.isArray(poppedItem) && poppedItem.toString() == ['trackPageView'].toString()) {
-            hasTrackPageViewViaPaqIndex = true;
+            hasTrackPageViewViaPaq = true;
         }
     }
 


### PR DESCRIPTION
### Description:

Added code to flush localPaq if no callback set but trackPageView set
Fixes: #PG-3463

### Review

* [ ] [Functional review done](https://developer.matomo.org/guides/pull-request-reviews#functional-review-done)
* [ ] [Potential edge cases thought about](https://developer.matomo.org/guides/pull-request-reviews#potential-edge-cases-thought-about) (behavior of the code with strange input, with strange internal state or possible interactions with other Matomo subsystems)
* [ ] [Usability review done](https://developer.matomo.org/guides/pull-request-reviews#usability-review-done) (is anything maybe unclear or think about anything that would cause people to reach out to support)
* [ ] [Security review done](https://developer.matomo.org/guides/security-in-piwik#checklist)
* [ ] [Wording review done](https://developer.matomo.org/guides/pull-request-reviews#translations-wording-review-done)
* [ ] [Code review done](https://developer.matomo.org/guides/pull-request-reviews#code-review-done)
* [ ] [Tests were added if useful/possible](https://developer.matomo.org/guides/pull-request-reviews#tests-were-added-if-usefulpossible)
* [ ] [Reviewed for breaking changes](https://developer.matomo.org/guides/pull-request-reviews#reviewed-for-breaking-changes)
* [ ] [Developer changelog updated if needed](https://developer.matomo.org/guides/pull-request-reviews#developer-changelog-updated-if-needed)
* [ ] [Documentation added if needed](https://developer.matomo.org/guides/pull-request-reviews#documentation-added-if-needed)
* [ ] Existing documentation updated if needed
