### PR TITLE
Ensure environment id is set

### DIFF
--- a/Context/WebContext.php
+++ b/Context/WebContext.php
@@ -92,10 +92,10 @@ class WebContext extends BaseContext
         $preconfiguredVariablesResponse = $this->getPreConfiguredVariablesJSCodeResponse(self::ID);
 
         foreach ($environments as $environment) {
-            $environmentId = $environment['id'];
+            $environmentId = $environment['id'] ?? false;
             // we make sure to have files even for containers that don't have a release yet, this way they can embed it
             // already nicely into the page and activate it later through the UI
-            if (!in_array($environmentId, $generatedEnvironments, true)) {
+            if ($environmentId && !in_array($environmentId, $generatedEnvironments, true)) {
                 $isPreviewRelease = $environmentId === Environment::ENVIRONMENT_PREVIEW;
                 if ($isPreviewRelease) {
                     $hasPreviewRelease = true;


### PR DESCRIPTION
### Description:

When debugging Dashboard UI tests locally I've seen the below warning several times

`
WARNING TagManager[2024-05-30 08:31:43.581651 UTC] [4c877] /Users/michal/Sites/matomo/plugins/TagManager/Context/WebContext.php(98): Warning - Undefined array key "id" - Matomo 5.2.0-alpha - Please report this message in the Matomo forums: https://forum.matomo.org (please do a search first as it might have been reported already)
`

so this is adding a safeguard for cases when the ID is not defined. Seems like in UI tests the environments may not be always accessible or not have the ID set, not sure. This change should not affect anything else as far as I can tell.

### Review

* [ ] [Functional review done](https://developer.matomo.org/guides/pull-request-reviews#functional-review-done)
* [ ] [Potential edge cases thought about](https://developer.matomo.org/guides/pull-request-reviews#potential-edge-cases-thought-about) (behavior of the code with strange input, with strange internal state or possible interactions with other Matomo subsystems)
* [ ] [Usability review done](https://developer.matomo.org/guides/pull-request-reviews#usability-review-done) (is anything maybe unclear or think about anything that would cause people to reach out to support)
* [ ] [Security review done](https://developer.matomo.org/guides/security-in-piwik#checklist)
* [ ] [Wording review done](https://developer.matomo.org/guides/pull-request-reviews#translations-wording-review-done)
* [ ] [Code review done](https://developer.matomo.org/guides/pull-request-reviews#code-review-done)
* [ ] [Tests were added if useful/possible](https://developer.matomo.org/guides/pull-request-reviews#tests-were-added-if-usefulpossible)
* [ ] [Reviewed for breaking changes](https://developer.matomo.org/guides/pull-request-reviews#reviewed-for-breaking-changes)
* [ ] [Developer changelog updated if needed](https://developer.matomo.org/guides/pull-request-reviews#developer-changelog-updated-if-needed)
* [ ] [Documentation added if needed](https://developer.matomo.org/guides/pull-request-reviews#documentation-added-if-needed)
* [ ] Existing documentation updated if needed
