### PR TITLE
Fixed issue where Shareaholic in-page app ID field wouldn't display

### DIFF
--- a/Template/Tag/ShareaholicTag.php
+++ b/Template/Tag/ShareaholicTag.php
@@ -50,7 +50,7 @@ class ShareaholicTag extends BaseTag
             $this->makeSetting('shareaholicAppId', '', FieldConfig::TYPE_STRING, function (FieldConfig $field) use ($InPageApp) {
                 $field->title = Piwik::translate('TagManager_ShareaholicTagAppIdTitle');
                 $field->description = Piwik::translate('TagManager_ShareaholicTagAppIdDescription');
-                $field->condition = 'shareaholicInPageApp && shareaholicInPageApp !== "total_share_count"';
+                $field->condition = 'shareaholicInPageApp=="share_buttons" || shareaholicInPageApp=="follow_buttons" || shareaholicInPageApp=="recommendations"';
                 $field->customFieldComponent = self::FIELD_VARIABLE_COMPONENT;
                 $field->validate = function ($value) use ($InPageApp, $field) {
                     if (!empty($InPageApp->getValue()) && $InPageApp->getValue() != 'total_share_count' && empty($value)) {

--- a/tests/System/expected/test_webContext__TagManager.getAvailableTagTypesInContext.xml
+++ b/tests/System/expected/test_webContext__TagManager.getAvailableTagTypesInContext.xml
@@ -1756,7 +1756,7 @@
 						<description>If you want to add an In-Page App enter the App ID here. It is about eight digits long. The App ID is not required for the Total Share Counter.</description>
 						<inlineHelp />
 						<introduction />
-						<condition>shareaholicInPageApp &amp;&amp; shareaholicInPageApp !== &quot;total_share_count&quot;</condition>
+						<condition>shareaholicInPageApp=="share_buttons" || shareaholicInPageApp=="follow_buttons" || shareaholicInPageApp=="recommendations"</condition>
 						<fullWidth>0</fullWidth>
 						<component>
 							<plugin>TagManager</plugin>


### PR DESCRIPTION
### Description:

It was noticed that the in-page app ID field, for the Shareaholic tag, was always hidden. This PR fixes that.

### Review

* [ ] [Functional review done](https://developer.matomo.org/guides/pull-request-reviews#functional-review-done)
* [ ] [Potential edge cases thought about](https://developer.matomo.org/guides/pull-request-reviews#potential-edge-cases-thought-about) (behavior of the code with strange input, with strange internal state or possible interactions with other Matomo subsystems)
* [ ] [Usability review done](https://developer.matomo.org/guides/pull-request-reviews#usability-review-done) (is anything maybe unclear or think about anything that would cause people to reach out to support)
* [ ] [Security review done](https://developer.matomo.org/guides/security-in-piwik#checklist)
* [ ] [Wording review done](https://developer.matomo.org/guides/pull-request-reviews#translations-wording-review-done)
* [ ] [Code review done](https://developer.matomo.org/guides/pull-request-reviews#code-review-done)
* [ ] [Tests were added if useful/possible](https://developer.matomo.org/guides/pull-request-reviews#tests-were-added-if-usefulpossible)
* [ ] [Reviewed for breaking changes](https://developer.matomo.org/guides/pull-request-reviews#reviewed-for-breaking-changes)
* [ ] [Developer changelog updated if needed](https://developer.matomo.org/guides/pull-request-reviews#developer-changelog-updated-if-needed)
* [ ] [Documentation added if needed](https://developer.matomo.org/guides/pull-request-reviews#documentation-added-if-needed)
* [ ] Existing documentation updated if needed
