### PR TITLE
Add explicit order by to sql statement

### DIFF
--- a/Dao/ContainerReleaseDao.php
+++ b/Dao/ContainerReleaseDao.php
@@ -71,7 +71,8 @@ class ContainerReleaseDao extends BaseDao implements TagManagerDao
         $sql = "SELECT crd.idcontainer, crd.idsite 
                 FROM $table crd 
                 LEFT JOIN $containerTable conr ON crd.idcontainer = conr.idcontainer 
-                WHERE conr.`status` = ? and crd.`status` = ? group by crd.idsite, crd.idcontainer";
+                WHERE conr.`status` = ? and crd.`status` = ? group by crd.idsite, crd.idcontainer
+                                                             order by crd.idsite, crd.idcontainer";
 
         $containers = Db::fetchAll($sql, array(self::STATUS_ACTIVE, self::STATUS_ACTIVE));
 


### PR DESCRIPTION
### Description:

While running core tests for TiDb, we came across a failing test for TagManager:

https://github.com/matomo-org/tag-manager/blob/691169cfb2b187d19eea339a5e368f3b4810a846/tests/Integration/Dao/ContainerReleaseDaoTest.php#L470-L493

The test basically fails, as for TiDb the order of returned items is different. For MySQL the order seems automatically ordered by `idsite` and `idcontainer`, for TiDb this isn't the case.

```
 ✘ GetAllReleasedContainers shouldOnlyReturnActiveReleasesWithContainers [5860.38 ms]
   │
   │ Failed asserting that two arrays are equal.
   │ --- Expected
   │ +++ Actual
   │ @@ @@
   │  Array (
   │      0 => Array (
   │ -        'idsite' => '2'
   │ +        'idsite' => '3'
   │          'idcontainer' => 'A68AGI3Z'
   │      )
   │      1 => Array (
   │ -        'idsite' => '3'
   │ -        'idcontainer' => 'A68AGI3Z'
   │ +        'idsite' => '4'
   │ +        'idcontainer' => 'foobar'
   │      )
   │      2 => Array (
   │          'idsite' => '4'
   │ -        'idcontainer' => 'A68AGI3Z'
   │ +        'idcontainer' => 'abcde'
   │      )
   │      3 => Array (
   │          'idsite' => '4'
   │ -        'idcontainer' => 'abcde'
   │ +        'idcontainer' => 'A68AGI3Z'
   │      )
   │      4 => Array (
   │ -        'idsite' => '4'
   │ -        'idcontainer' => 'foobar'
   │ +        'idsite' => '2'
   │ +        'idcontainer' => 'A68AGI3Z'
   │      )
   │  )
   │
   │ /home/runner/work/matomo/matomo/matomo/plugins/TagManager/tests/Integration/Dao/ContainerReleaseDaoTest.php:491
```

Adding an explicit `order by` to the query ensures the same results across different database engines.

### Review

* [ ] [Functional review done](https://developer.matomo.org/guides/pull-request-reviews#functional-review-done)
* [ ] [Potential edge cases thought about](https://developer.matomo.org/guides/pull-request-reviews#potential-edge-cases-thought-about) (behavior of the code with strange input, with strange internal state or possible interactions with other Matomo subsystems)
* [ ] [Usability review done](https://developer.matomo.org/guides/pull-request-reviews#usability-review-done) (is anything maybe unclear or think about anything that would cause people to reach out to support)
* [ ] [Security review done](https://developer.matomo.org/guides/security-in-piwik#checklist)
* [ ] [Wording review done](https://developer.matomo.org/guides/pull-request-reviews#translations-wording-review-done)
* [ ] [Code review done](https://developer.matomo.org/guides/pull-request-reviews#code-review-done)
* [ ] [Tests were added if useful/possible](https://developer.matomo.org/guides/pull-request-reviews#tests-were-added-if-usefulpossible)
* [ ] [Reviewed for breaking changes](https://developer.matomo.org/guides/pull-request-reviews#reviewed-for-breaking-changes)
* [ ] [Developer changelog updated if needed](https://developer.matomo.org/guides/pull-request-reviews#developer-changelog-updated-if-needed)
* [ ] [Documentation added if needed](https://developer.matomo.org/guides/pull-request-reviews#documentation-added-if-needed)
* [ ] Existing documentation updated if needed
