### PR TITLE
Fixes Disable Preview text not displaying in mobile menu due to translation, #PG-3768

### DIFF
--- a/TagManager.php
+++ b/TagManager.php
@@ -905,6 +905,7 @@ class TagManager extends \Piwik\Plugin
         $result[] = 'TagManager_DiffAddedPaused';
         $result[] = 'TagManager_TagFireLimitAllowedInPreviewModeTitle';
         $result[] = 'TagManager_TagFireLimitAllowedInPreviewModeDescription';
+        $result[] = 'TagManager_DisablePreview';
     }
 
     public function getStylesheetFiles(&$stylesheets)


### PR DESCRIPTION
### Description:

Fixes Disable Preview text not displaying in mobile menu due to translation.
Fixes: #PG-3768


### Review

* [ ] [Functional review done](https://developer.matomo.org/guides/pull-request-reviews#functional-review-done)
* [ ] [Potential edge cases thought about](https://developer.matomo.org/guides/pull-request-reviews#potential-edge-cases-thought-about) (behavior of the code with strange input, with strange internal state or possible interactions with other Matomo subsystems)
* [ ] [Usability review done](https://developer.matomo.org/guides/pull-request-reviews#usability-review-done) (is anything maybe unclear or think about anything that would cause people to reach out to support)
* [ ] [Security review done](https://developer.matomo.org/guides/security-in-piwik#checklist)
* [ ] [Wording review done](https://developer.matomo.org/guides/pull-request-reviews#translations-wording-review-done)
* [ ] [Code review done](https://developer.matomo.org/guides/pull-request-reviews#code-review-done)
* [ ] [Tests were added if useful/possible](https://developer.matomo.org/guides/pull-request-reviews#tests-were-added-if-usefulpossible)
* [ ] [Reviewed for breaking changes](https://developer.matomo.org/guides/pull-request-reviews#reviewed-for-breaking-changes)
* [ ] [Developer changelog updated if needed](https://developer.matomo.org/guides/pull-request-reviews#developer-changelog-updated-if-needed)
* [ ] [Documentation added if needed](https://developer.matomo.org/guides/pull-request-reviews#documentation-added-if-needed)
* [ ] Existing documentation updated if needed
