### PR TITLE
Adds tracking of bot option in Matomo configuration variable, #PG-3361

### DIFF
--- a/TagManager.php
+++ b/TagManager.php
@@ -906,6 +906,9 @@ class TagManager extends \Piwik\Plugin
         $result[] = 'TagManager_TagFireLimitAllowedInPreviewModeTitle';
         $result[] = 'TagManager_TagFireLimitAllowedInPreviewModeDescription';
         $result[] = 'TagManager_DisablePreview';
+        $result[] = 'TagManager_MatomoConfigurationMatomoTrackBotsTitle';
+        $result[] = 'TagManager_MatomoConfigurationMatomoTrackBotsDescription';
+        $result[] = 'TagManager_MatomoConfigurationMatomoTrackBotsInlineHelp';
     }
 
     public function getStylesheetFiles(&$stylesheets)

--- a/TagManager.php
+++ b/TagManager.php
@@ -908,7 +908,6 @@ class TagManager extends \Piwik\Plugin
         $result[] = 'TagManager_DisablePreview';
         $result[] = 'TagManager_MatomoConfigurationMatomoTrackBotsTitle';
         $result[] = 'TagManager_MatomoConfigurationMatomoTrackBotsDescription';
-        $result[] = 'TagManager_MatomoConfigurationMatomoTrackBotsInlineHelp';
     }
 
     public function getStylesheetFiles(&$stylesheets)

--- a/Template/Tag/MatomoTag.web.js
+++ b/Template/Tag/MatomoTag.web.js
@@ -239,6 +239,9 @@
                     if (matomoConfig.trackVisibleContentImpressions) {
                         tracker.trackVisibleContentImpressions();
                     }
+                    if (matomoConfig.trackBots) {
+                        tracker.appendToTrackingUrl('bots=1');
+                    }
                     if (matomoConfig.hasOwnProperty('enableFormAnalytics') && !matomoConfig.enableFormAnalytics && window.Matomo && window.Matomo.FormAnalytics && typeof window.Matomo.FormAnalytics.disableFormAnalytics === 'function') {
                         window.Matomo.FormAnalytics.disableFormAnalytics();
                     }

--- a/Template/Variable/MatomoConfigurationVariable.php
+++ b/Template/Variable/MatomoConfigurationVariable.php
@@ -146,6 +146,11 @@ class MatomoConfigurationVariable extends BaseVariable
                 $field->title = Piwik::translate('TagManager_MatomoConfigurationMatomoTrackVisibleContentImpressionsTitle');
                 $field->description = Piwik::translate('TagManager_MatomoConfigurationMatomoTrackVisibleContentImpressionsDescription');
             }),
+            $this->makeSetting('trackBots', false, FieldConfig::TYPE_BOOL, function (FieldConfig $field) {
+                $field->title = Piwik::translate('TagManager_MatomoConfigurationMatomoTrackBotsTitle');
+                $field->description = Piwik::translate('TagManager_MatomoConfigurationMatomoTrackBotsDescription');
+                $field->inlineHelp = Piwik::translate('TagManager_MatomoConfigurationMatomoTrackBotsInlineHelp', array('<strong>', '</strong>'));
+            }),
             $this->makeSetting('disableCookies', false, FieldConfig::TYPE_BOOL, function (FieldConfig $field) {
                 $field->title = Piwik::translate('TagManager_MatomoConfigurationMatomoDisableCookiesTitle');
                 $field->description = Piwik::translate('TagManager_MatomoConfigurationMatomoDisableCookiesDescription');

--- a/Template/Variable/MatomoConfigurationVariable.php
+++ b/Template/Variable/MatomoConfigurationVariable.php
@@ -149,7 +149,6 @@ class MatomoConfigurationVariable extends BaseVariable
             $this->makeSetting('trackBots', false, FieldConfig::TYPE_BOOL, function (FieldConfig $field) {
                 $field->title = Piwik::translate('TagManager_MatomoConfigurationMatomoTrackBotsTitle');
                 $field->description = Piwik::translate('TagManager_MatomoConfigurationMatomoTrackBotsDescription');
-                $field->inlineHelp = Piwik::translate('TagManager_MatomoConfigurationMatomoTrackBotsInlineHelp', array('<strong>', '</strong>'));
             }),
             $this->makeSetting('disableCookies', false, FieldConfig::TYPE_BOOL, function (FieldConfig $field) {
                 $field->title = Piwik::translate('TagManager_MatomoConfigurationMatomoDisableCookiesTitle');

--- a/Updates/5.2.0-b1.php
+++ b/Updates/5.2.0-b1.php
@@ -10,7 +10,9 @@
 namespace Piwik\Plugins\TagManager;
 
 use Piwik\Plugins\TagManager\Template\Tag\MatomoTag;
+use Piwik\Plugins\TagManager\Template\Variable\MatomoConfigurationVariable;
 use Piwik\Plugins\TagManager\UpdateHelper\NewTagParameterMigrator;
+use Piwik\Plugins\TagManager\UpdateHelper\NewVariableParameterMigrator;
 use Piwik\Updater;
 use Piwik\Updater\Migration;
 use Piwik\Updater\Migration\Factory as MigrationFactory;
@@ -60,5 +62,8 @@ class Updates_5_2_0_b1 extends PiwikUpdates
     public function doUpdate(Updater $updater)
     {
         $updater->executeMigrations(__FILE__, $this->getMigrations($updater));
+
+        $migrator = new NewVariableParameterMigrator(MatomoConfigurationVariable::ID, 'trackBots', false);
+        $migrator->migrate();
     }
 }

--- a/lang/en.json
+++ b/lang/en.json
@@ -1058,6 +1058,9 @@
         "DiffPaused": "Paused",
         "DiffAddedPaused": "Added in paused state",
         "TagFireLimitAllowedInPreviewModeTitle": "Enable tag fire limits to work in preview mode",
-        "TagFireLimitAllowedInPreviewModeDescription": "Enable this option to check if fire limits, such as once-per-lifetime, work as expected when preview mode is enabled."
+        "TagFireLimitAllowedInPreviewModeDescription": "Enable this option to check if fire limits, such as once-per-lifetime, work as expected when preview mode is enabled.",
+        "MatomoConfigurationMatomoTrackBotsTitle": "Track Bots",
+        "MatomoConfigurationMatomoTrackBotsDescription": "Enable this feature to track bots into your website. By default bots are not tracked",
+        "MatomoConfigurationMatomoTrackBotsInlineHelp": "%1$sNote:  When enabled it sets paq.push(['appendToTrackingUrl', 'bots=1']); which will enable tracking of bots.%2$s"
     }
 }

--- a/lang/en.json
+++ b/lang/en.json
@@ -1060,7 +1060,6 @@
         "TagFireLimitAllowedInPreviewModeTitle": "Enable tag fire limits to work in preview mode",
         "TagFireLimitAllowedInPreviewModeDescription": "Enable this option to check if fire limits, such as once-per-lifetime, work as expected when preview mode is enabled.",
         "MatomoConfigurationMatomoTrackBotsTitle": "Track Bots",
-        "MatomoConfigurationMatomoTrackBotsDescription": "Enable this feature to track bots into your website. By default bots are not tracked",
-        "MatomoConfigurationMatomoTrackBotsInlineHelp": "%1$sNote:  When enabled it sets paq.push(['appendToTrackingUrl', 'bots=1']); which will enable tracking of bots.%2$s"
+        "MatomoConfigurationMatomoTrackBotsDescription": "By default, Matomo doesn't track visits by bots in order to show accurate visitor metrics. Enable this feature to add tracking for bot visits."
     }
 }

--- a/tests/System/expected/test___TagManager.exportContainerVersion_site_default_container.xml
+++ b/tests/System/expected/test___TagManager.exportContainerVersion_site_default_container.xml
@@ -97,6 +97,7 @@
 				<heartBeatTime>15</heartBeatTime>
 				<trackAllContentImpressions>0</trackAllContentImpressions>
 				<trackVisibleContentImpressions>0</trackVisibleContentImpressions>
+				<trackBots>0</trackBots>
 				<disableCookies>0</disableCookies>
 				<requireConsent>0</requireConsent>
 				<requireCookieConsent>0</requireCookieConsent>

--- a/tests/System/expected/test_webContext__TagManager.getAvailableVariableTypesInContext.xml
+++ b/tests/System/expected/test_webContext__TagManager.getAvailableVariableTypesInContext.xml
@@ -1062,6 +1062,22 @@
 						<fullWidth>0</fullWidth>
 					</row>
 					<row>
+						<name>trackBots</name>
+						<title>Track Bots</title>
+						<value>0</value>
+						<defaultValue>0</defaultValue>
+						<type>boolean</type>
+						<uiControl>checkbox</uiControl>
+						<uiControlAttributes>
+						</uiControlAttributes>
+						<availableValues />
+						<description>By default, Matomo doesn't track visits by bots in order to show accurate visitor metrics. Enable this feature to add tracking for bot visits.</description>
+						<inlineHelp />
+						<introduction />
+						<condition />
+						<fullWidth>0</fullWidth>
+					</row>
+					<row>
 						<name>disableCookies</name>
 						<title>Disable cookies</title>
 						<value>0</value>


### PR DESCRIPTION
### Description:

Adds tracking of bot option in Matomo configuration variable
Fixes: #PG-3361, #771

### Review

* [ ] [Functional review done](https://developer.matomo.org/guides/pull-request-reviews#functional-review-done)
* [ ] [Potential edge cases thought about](https://developer.matomo.org/guides/pull-request-reviews#potential-edge-cases-thought-about) (behavior of the code with strange input, with strange internal state or possible interactions with other Matomo subsystems)
* [ ] [Usability review done](https://developer.matomo.org/guides/pull-request-reviews#usability-review-done) (is anything maybe unclear or think about anything that would cause people to reach out to support)
* [ ] [Security review done](https://developer.matomo.org/guides/security-in-piwik#checklist)
* [ ] [Wording review done](https://developer.matomo.org/guides/pull-request-reviews#translations-wording-review-done)
* [ ] [Code review done](https://developer.matomo.org/guides/pull-request-reviews#code-review-done)
* [ ] [Tests were added if useful/possible](https://developer.matomo.org/guides/pull-request-reviews#tests-were-added-if-usefulpossible)
* [ ] [Reviewed for breaking changes](https://developer.matomo.org/guides/pull-request-reviews#reviewed-for-breaking-changes)
* [ ] [Developer changelog updated if needed](https://developer.matomo.org/guides/pull-request-reviews#developer-changelog-updated-if-needed)
* [ ] [Documentation added if needed](https://developer.matomo.org/guides/pull-request-reviews#documentation-added-if-needed)
* [ ] Existing documentation updated if needed
