### PR TITLE
Implement new HTML attribute variable

### DIFF
--- a/Template/Variable/ClickHtmlAttributeVariable.php
+++ b/Template/Variable/ClickHtmlAttributeVariable.php
@@ -1,0 +1,67 @@
+<?php
+/**
+ * Matomo - free/libre analytics platform
+ *
+ * @link https://matomo.org
+ * @license http://www.gnu.org/licenses/gpl-3.0.html GPL v3 or later
+ */
+namespace Piwik\Plugins\TagManager\Template\Variable;
+
+use Piwik\Piwik;
+use Piwik\Settings\FieldConfig;
+use Piwik\Validators\NotEmpty;
+
+class ClickHtmlAttributeVariable extends BaseVariable
+{
+    public function getCategory()
+    {
+        return self::CATEGORY_CLICKS;
+    }
+
+    public function getName()
+    {
+        // By default, the name will be automatically fetched from the TagManager_DataValueVariableName translation key.
+        // you can either adjust/create/remove this translation key, or return a different value here directly.
+        return parent::getName();
+    }
+
+    public function getDescription()
+    {
+        // By default, the description will be automatically fetched from the TagManager_DataValueVariableDescription
+        // translation key. you can either adjust/create/remove this translation key, or return a different value
+        // here directly.
+        return parent::getDescription();
+    }
+
+    public function getHelp()
+    {
+        // By default, the help will be automatically fetched from the TagManager_DataValueVariableHelp translation key.
+        // you can either adjust/create/remove this translation key, or return a different value here directly.
+        return parent::getHelp();
+    }
+
+    public function getIcon()
+    {
+        // You may optionally specify a path to an image icon URL, for example:
+        //
+        // return 'plugins/TagManager/images/MyIcon.png';
+        //
+        // The image should have ideally a resolution of about 64x64 pixels.
+        return 'plugins/TagManager/images/icons/click-data-attribute-variable.svg';
+    }
+
+    public function getParameters()
+    {
+        return array(
+            $this->makeSetting('htmlAttribute', '', FieldConfig::TYPE_STRING, function (FieldConfig $field) {
+                $field->title = Piwik::translate('TagManager_ClickHtmlAttributeAttributeTitle');
+                $field->description = Piwik::translate('TagManager_ClickHtmlAttributeAttributeDescription');
+                $field->uiControlAttributes = ['placeholder' => Piwik::translate('TagManager_ClickHtmlAttributeAttributePlaceholder')];
+                $field->uiControl = FieldConfig::UI_CONTROL_TEXT;
+                $field->validators[] = new NotEmpty();
+            }),
+
+        );
+    }
+
+}

--- a/Template/Variable/ClickHtmlAttributeVariable.web.js
+++ b/Template/Variable/ClickHtmlAttributeVariable.web.js
@@ -1,0 +1,15 @@
+(function () {
+  return function (parameters, TagManager) {
+
+    this.get = function () {
+      var htmlAttribute = parameters.get("htmlAttribute");
+
+      var event = TagManager.dataLayer.events.at(-1);
+
+      if (event["mtm.clickElement"] && htmlAttribute && event["mtm.clickElement"].hasAttribute(htmlAttribute)) {
+        return event["mtm.clickElement"].getAttribute(htmlAttribute);
+      }
+
+    };
+  };
+})();

--- a/lang/en.json
+++ b/lang/en.json
@@ -1060,6 +1060,12 @@
         "TagFireLimitAllowedInPreviewModeTitle": "Enable tag fire limits to work in preview mode",
         "TagFireLimitAllowedInPreviewModeDescription": "Enable this option to check if fire limits, such as once-per-lifetime, work as expected when preview mode is enabled.",
         "MatomoConfigurationMatomoTrackBotsTitle": "Track Bots",
-        "MatomoConfigurationMatomoTrackBotsDescription": "By default, Matomo doesn't track visits by bots in order to show accurate visitor metrics. Enable this feature to add tracking for bot visits."
+        "MatomoConfigurationMatomoTrackBotsDescription": "By default, Matomo doesn't track visits by bots in order to show accurate visitor metrics. Enable this feature to add tracking for bot visits.",
+        "ClickHtmlAttributeVariableName": "Clicked HTML Attribute",
+        "ClickHtmlAttributeVariableDescription": "Reads a custom value from the clicked HTML attribute.",
+        "ClickHtmlAttributeVariableHelp": "Using this variable you can access any value that is available within the clicked HTML attribute.",
+        "ClickHtmlAttributeAttributeTitle": "Clicked HTML Attribute Name",
+        "ClickHtmlAttributeAttributeDescription": "The name of the attribute, such as title, alt, or any other HTML attribute.",
+        "ClickHtmlAttributeAttributePlaceholder": "e.g. title"
     }
 }

--- a/lang/en.json
+++ b/lang/en.json
@@ -1065,7 +1065,7 @@
         "ClickHtmlAttributeVariableDescription": "Reads a custom value from the clicked HTML attribute.",
         "ClickHtmlAttributeVariableHelp": "Using this variable you can access any value that is available within the clicked HTML attribute.",
         "ClickHtmlAttributeAttributeTitle": "Clicked HTML Attribute Name",
-        "ClickHtmlAttributeAttributeDescription": "The name of the attribute, such as title, alt, or any other HTML attribute.",
-        "ClickHtmlAttributeAttributePlaceholder": "e.g. title"
+        "ClickHtmlAttributeAttributeDescription": "The name of the attribute, such as title, value, alt, or any other HTML attribute.",
+        "ClickHtmlAttributeAttributePlaceholder": "e.g. value"
     }
 }

--- a/tests/System/expected/test_webContext__TagManager.getAvailableVariableTypesInContext.xml
+++ b/tests/System/expected/test_webContext__TagManager.getAvailableVariableTypesInContext.xml
@@ -36,6 +36,39 @@
 					</row>
 				</parameters>
 			</row>
+			<row>
+				<id>ClickHtmlAttribute</id>
+				<name>Clicked HTML Attribute</name>
+				<description>Reads a custom value from the clicked HTML attribute.</description>
+				<category>Clicks</category>
+				<icon>plugins/TagManager/images/icons/click-data-attribute-variable.svg</icon>
+				<help>Using this variable you can access any value that is available within the clicked HTML attribute.</help>
+				<order>9999</order>
+				<contexts>
+					<row>web</row>
+				</contexts>
+				<hasAdvancedSettings>1</hasAdvancedSettings>
+				<isCustomTemplate>0</isCustomTemplate>
+				<parameters>
+					<row>
+						<name>htmlAttribute</name>
+						<title>Clicked HTML Attribute Name</title>
+						<value/>
+						<defaultValue/>
+						<type>string</type>
+						<uiControl>text</uiControl>
+						<uiControlAttributes>
+							<placeholder>e.g. title</placeholder>
+						</uiControlAttributes>
+						<availableValues/>
+						<description>The name of the attribute, such as title, alt, or any other HTML attribute.</description>
+						<inlineHelp/>
+						<introduction/>
+						<condition/>
+						<fullWidth>0</fullWidth>
+					</row>
+				</parameters>
+			</row>
 		</types>
 	</row>
 	<row>

--- a/tests/System/expected/test_webContext__TagManager.getAvailableVariableTypesInContext.xml
+++ b/tests/System/expected/test_webContext__TagManager.getAvailableVariableTypesInContext.xml
@@ -58,10 +58,10 @@
 						<type>string</type>
 						<uiControl>text</uiControl>
 						<uiControlAttributes>
-							<placeholder>e.g. title</placeholder>
+							<placeholder>e.g. value</placeholder>
 						</uiControlAttributes>
 						<availableValues/>
-						<description>The name of the attribute, such as title, alt, or any other HTML attribute.</description>
+						<description>The name of the attribute, such as title, value, alt, or any other HTML attribute.</description>
 						<inlineHelp/>
 						<introduction/>
 						<condition/>

--- a/tests/UI/expected-screenshots/ContainerVariable_create_new.png
+++ b/tests/UI/expected-screenshots/ContainerVariable_create_new.png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:6690db06d216a52ef9cb0140670b7bc07d410ba04fdbedc6e54abb7e93c1de26
-size 191938
+oid sha256:d9e48f42119b308c541d1802fbf04af7cd2658ff3b2d8fc1c6ee312781fd3b62
+size 200545

--- a/tests/UI/expected-screenshots/ContainerVariable_create_new_custom_templates_restricted.png
+++ b/tests/UI/expected-screenshots/ContainerVariable_create_new_custom_templates_restricted.png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:92320b058ace6f6b203c88be29c8a307cb639b5b9678f8cb36b60c581b7b3ef9
-size 190447
+oid sha256:c5a662b5493c59669db3d31ef120adca4f28640e38cdbe1ed0833739e13094a9
+size 199591

--- a/tests/UI/expected-screenshots/ContainerVariable_variable_none_exist_yet_create_now.png
+++ b/tests/UI/expected-screenshots/ContainerVariable_variable_none_exist_yet_create_now.png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:eaaf3618f9eee42315c843e900e7a5479907bb9f901cb26978b004ccca6ee2c5
-size 151509
+oid sha256:3b09022675ce7fe5dbacac4929968e38af7e58a137d6ed4ac7816a2fd80719e6
+size 160001


### PR DESCRIPTION
### Description:

Customers have been asking for access to other click attributes than what's available. This implements a new variable type where the specific HTML attribute name can be provided.

Fixes: #490 #757 

### Review

* [ ] [Functional review done](https://developer.matomo.org/guides/pull-request-reviews#functional-review-done)
* [ ] [Potential edge cases thought about](https://developer.matomo.org/guides/pull-request-reviews#potential-edge-cases-thought-about) (behavior of the code with strange input, with strange internal state or possible interactions with other Matomo subsystems)
* [ ] [Usability review done](https://developer.matomo.org/guides/pull-request-reviews#usability-review-done) (is anything maybe unclear or think about anything that would cause people to reach out to support)
* [ ] [Security review done](https://developer.matomo.org/guides/security-in-piwik#checklist)
* [ ] [Wording review done](https://developer.matomo.org/guides/pull-request-reviews#translations-wording-review-done)
* [ ] [Code review done](https://developer.matomo.org/guides/pull-request-reviews#code-review-done)
* [ ] [Tests were added if useful/possible](https://developer.matomo.org/guides/pull-request-reviews#tests-were-added-if-usefulpossible)
* [ ] [Reviewed for breaking changes](https://developer.matomo.org/guides/pull-request-reviews#reviewed-for-breaking-changes)
* [ ] [Developer changelog updated if needed](https://developer.matomo.org/guides/pull-request-reviews#developer-changelog-updated-if-needed)
* [ ] [Documentation added if needed](https://developer.matomo.org/guides/pull-request-reviews#documentation-added-if-needed)
* [ ] Existing documentation updated if needed
