### PR TITLE
Textual changes for Event value and default Matomo tag name, #PG-3818, #PG-3856

### DIFF
--- a/API.php
+++ b/API.php
@@ -434,7 +434,7 @@ class API extends \Piwik\Plugin\API
             'idContainer' => $idContainer,
             'idContainerVersion' => $draftVersion,
             'type' => MatomoTag::ID,
-            'name' => Piwik::translate('TagManager_PageViewTriggerName'),
+            'name' => Piwik::translate('TagManager_MatomoTagName'),
             'fireTriggerIds' => array($idTrigger),
             'parameters' => array(
                 MatomoTag::PARAM_MATOMO_CONFIG => '{{'. Piwik::translate('TagManager_MatomoConfigurationVariableName').'}}'

--- a/Template/Tag/MatomoTag.php
+++ b/Template/Tag/MatomoTag.php
@@ -192,7 +192,8 @@ class MatomoTag extends BaseTag
             $this->makeSetting('eventValue', '', FieldConfig::TYPE_STRING, function (FieldConfig $field) {
                 $field->title = Piwik::translate('TagManager_EventValue');
                 $field->customFieldComponent = self::FIELD_VARIABLE_COMPONENT;
-                $field->description = Piwik::translate('TagManager_EventValueHelp');
+                $field->description = Piwik::translate('TagManager_EventValueDescription');
+                $field->inlineHelp = '<br>' . Piwik::translate('TagManager_EventValueInlineHelp', array('<strong>', '</strong>'));
                 $field->condition = 'trackingType == "event"';
                 $field->validators[] = new CharacterLength(0, 500);
                 $field->validators[] = new Numeric(true, true);

--- a/lang/en.json
+++ b/lang/en.json
@@ -394,6 +394,8 @@
         "EventNameHelp": "The event's object Name, for example a particular Movie name, or Song name, or File name…",
         "EventValue": "Event Value",
         "EventValueHelp": "The event's value, for example \"50\" as in user has stayed on the website for 50 seconds.",
+        "EventValueDescription": "Specify a value or choose a variable.",
+        "EventValueInlineHelp": "%1$sNote:%2$s The value must be %1$snumeric%2$s. Negative values are allowed but non-numeric values will automatically be replaced with 0.",
         "EventValueException": "The event value can only include numeric values and variables.",
         "Except": "Except",
         "ExportDraft": "Export draft",

--- a/tests/System/expected/test___TagManager.exportContainerVersion_site_default_container.xml
+++ b/tests/System/expected/test___TagManager.exportContainerVersion_site_default_container.xml
@@ -26,7 +26,7 @@
 		<row>
 			<idtag>31</idtag>
 			<type>Matomo</type>
-			<name>Pageview</name>
+			<name>Matomo Analytics</name>
 			<description />
 			<status>active</status>
 			<parameters>

--- a/tests/System/expected/test_webContext__TagManager.getAvailableTagTypesInContext.xml
+++ b/tests/System/expected/test_webContext__TagManager.getAvailableTagTypesInContext.xml
@@ -459,8 +459,8 @@
 						<uiControlAttributes>
 						</uiControlAttributes>
 						<availableValues />
-						<description>The event's value, for example &quot;50&quot; as in user has stayed on the website for 50 seconds.</description>
-						<inlineHelp />
+						<description>Specify a value or choose a variable.</description>
+						<inlineHelp>&lt;br&gt;&lt;strong&gt;Note:&lt;/strong&gt; The value must be &lt;strong&gt;numeric&lt;/strong&gt;. Negative values are allowed but non-numeric values will automatically be replaced with 0.</inlineHelp>
 						<introduction />
 						<condition>trackingType == &quot;event&quot;</condition>
 						<fullWidth>0</fullWidth>


### PR DESCRIPTION
### Description:

Textual changes for Event value and default Matomo tag name
Fixes: #PG-3818 and #PG-3856

### Review

* [ ] [Functional review done](https://developer.matomo.org/guides/pull-request-reviews#functional-review-done)
* [ ] [Potential edge cases thought about](https://developer.matomo.org/guides/pull-request-reviews#potential-edge-cases-thought-about) (behavior of the code with strange input, with strange internal state or possible interactions with other Matomo subsystems)
* [ ] [Usability review done](https://developer.matomo.org/guides/pull-request-reviews#usability-review-done) (is anything maybe unclear or think about anything that would cause people to reach out to support)
* [ ] [Security review done](https://developer.matomo.org/guides/security-in-piwik#checklist)
* [ ] [Wording review done](https://developer.matomo.org/guides/pull-request-reviews#translations-wording-review-done)
* [ ] [Code review done](https://developer.matomo.org/guides/pull-request-reviews#code-review-done)
* [ ] [Tests were added if useful/possible](https://developer.matomo.org/guides/pull-request-reviews#tests-were-added-if-usefulpossible)
* [ ] [Reviewed for breaking changes](https://developer.matomo.org/guides/pull-request-reviews#reviewed-for-breaking-changes)
* [ ] [Developer changelog updated if needed](https://developer.matomo.org/guides/pull-request-reviews#developer-changelog-updated-if-needed)
* [ ] [Documentation added if needed](https://developer.matomo.org/guides/pull-request-reviews#documentation-added-if-needed)
* [ ] Existing documentation updated if needed
