### PR TITLE
Ensure plugin is activated for tests

### DIFF
--- a/tests/Fixtures/TagManagerFixture.php
+++ b/tests/Fixtures/TagManagerFixture.php
@@ -11,6 +11,7 @@ namespace Piwik\Plugins\TagManager\tests\Fixtures;
 
 use Piwik\Container\StaticContainer;
 use Piwik\Date;
+use Piwik\Plugin\Manager;
 use Piwik\Plugins\TagManager\API;
 use Piwik\Plugins\TagManager\Context\WebContext;
 use Piwik\Plugins\TagManager\Dao\ContainersDao;
@@ -63,6 +64,9 @@ class TagManagerFixture extends Fixture
 
     public function setUp(): void
     {
+        // Ensure plugin is activated, otherwise adding a site with this type will fail
+        Manager::getInstance()->activatePlugin('MobileAppMeasurable');
+
         $this->setUpWebsite();
         $this->setUpContainers();
         $this->trackFirstVisit();


### PR DESCRIPTION
### Description:

This fixture tries to add a measurable of the type `mobileapp`. The SitesManager API currently does not validate the measurable type provided, but we aim to change this with https://github.com/matomo-org/matomo/pull/22704.

To ensure the tests pass, it's thus required to enable the plugin for it.

### Review

* [ ] [Functional review done](https://developer.matomo.org/guides/pull-request-reviews#functional-review-done)
* [ ] [Potential edge cases thought about](https://developer.matomo.org/guides/pull-request-reviews#potential-edge-cases-thought-about) (behavior of the code with strange input, with strange internal state or possible interactions with other Matomo subsystems)
* [ ] [Usability review done](https://developer.matomo.org/guides/pull-request-reviews#usability-review-done) (is anything maybe unclear or think about anything that would cause people to reach out to support)
* [ ] [Security review done](https://developer.matomo.org/guides/security-in-piwik#checklist)
* [ ] [Wording review done](https://developer.matomo.org/guides/pull-request-reviews#translations-wording-review-done)
* [ ] [Code review done](https://developer.matomo.org/guides/pull-request-reviews#code-review-done)
* [ ] [Tests were added if useful/possible](https://developer.matomo.org/guides/pull-request-reviews#tests-were-added-if-usefulpossible)
* [ ] [Reviewed for breaking changes](https://developer.matomo.org/guides/pull-request-reviews#reviewed-for-breaking-changes)
* [ ] [Developer changelog updated if needed](https://developer.matomo.org/guides/pull-request-reviews#developer-changelog-updated-if-needed)
* [ ] [Documentation added if needed](https://developer.matomo.org/guides/pull-request-reviews#documentation-added-if-needed)
* [ ] Existing documentation updated if needed
