### PR TITLE
Disable spellcheck for customHTML text box, #PG-4001

### DIFF
--- a/Template/Tag/CustomHtmlTag.php
+++ b/Template/Tag/CustomHtmlTag.php
@@ -46,6 +46,7 @@ class CustomHtmlTag extends BaseTag
                     ['<a rel="noreferrer noopener" target="_blank" href="' . Url::addCampaignParametersToMatomoLink('https://matomo.org/faq/tag-manager/faq_26815/', null, null, 'App.TagManager.getParameters') . '">', '</a>']
                 );
                 $field->validators[] = new NotEmpty();
+                $field->uiControlAttributes = ['spellcheck' => 'false'];
             }),
             $this->makeSetting('htmlPosition', 'bodyEnd', FieldConfig::TYPE_STRING, function (FieldConfig $field) {
                 $field->title = Piwik::translate('TagManager_CustomHtmlHtmlPositionTitle');

--- a/tests/Integration/Model/TagTest.php
+++ b/tests/Integration/Model/TagTest.php
@@ -274,6 +274,7 @@ class TagTest extends IntegrationTestCase
                                     'uiControl' => 'textarea',
                                     'uiControlAttributes' =>
                                          [
+                                             'spellcheck' => 'false'
                                         ],
                                     'availableValues' => null,
                                     'description' => 'This tag is ideal when you need to add for example custom styles or custom JavaScript or when you are looking for a specific tag which is not yet supported. With this tag you can append any HTML to the bottom of your page, add styles, or execute JavaScript. Note: You can replace content within the HTML with variables by putting a variable name in curly brackets like this {{PageUrl}}.',
@@ -293,7 +294,8 @@ class TagTest extends IntegrationTestCase
                                     'defaultValue' => 'bodyEnd',
                                     'type' => 'string',
                                     'uiControl' => 'select',
-                                    'uiControlAttributes' => [],
+                                    'uiControlAttributes' => [
+                                    ],
                                     'availableValues' => [
                                         'headStart' => 'Head Start',
                                         'headEnd' => 'Head End',
@@ -369,6 +371,7 @@ class TagTest extends IntegrationTestCase
                                     'uiControl' => 'textarea',
                                     'uiControlAttributes' =>
                                          [
+                                             'spellcheck' => 'false'
                                         ],
                                     'availableValues' => null,
                                     'description' => 'This tag is ideal when you need to add for example custom styles or custom JavaScript or when you are looking for a specific tag which is not yet supported. With this tag you can append any HTML to the bottom of your page, add styles, or execute JavaScript. Note: You can replace content within the HTML with variables by putting a variable name in curly brackets like this {{PageUrl}}.',
@@ -388,7 +391,8 @@ class TagTest extends IntegrationTestCase
                                     'defaultValue' => 'bodyEnd',
                                     'type' => 'string',
                                     'uiControl' => 'select',
-                                    'uiControlAttributes' => [],
+                                    'uiControlAttributes' => [
+                                    ],
                                     'availableValues' => [
                                         'headStart' => 'Head Start',
                                         'headEnd' => 'Head End',
@@ -560,6 +564,7 @@ class TagTest extends IntegrationTestCase
                                 'uiControl' => 'textarea',
                                 'uiControlAttributes' =>
                                      [
+                                         'spellcheck' => 'false'
                                     ],
                                 'availableValues' => null,
                                 'description' => 'This tag is ideal when you need to add for example custom styles or custom JavaScript or when you are looking for a specific tag which is not yet supported. With this tag you can append any HTML to the bottom of your page, add styles, or execute JavaScript. Note: You can replace content within the HTML with variables by putting a variable name in curly brackets like this {{PageUrl}}.',
@@ -579,7 +584,8 @@ class TagTest extends IntegrationTestCase
                                 'defaultValue' => 'bodyEnd',
                                 'type' => 'string',
                                 'uiControl' => 'select',
-                                'uiControlAttributes' => [],
+                                'uiControlAttributes' => [
+                                ],
                                 'availableValues' => [
                                     'headStart' => 'Head Start',
                                     'headEnd' => 'Head End',
@@ -926,6 +932,7 @@ class TagTest extends IntegrationTestCase
                                     'uiControl' => 'textarea',
                                     'uiControlAttributes' =>
                                          [
+                                             'spellcheck' => 'false'
                                         ],
                                     'availableValues' => null,
                                     'description' => 'This tag is ideal when you need to add for example custom styles or custom JavaScript or when you are looking for a specific tag which is not yet supported. With this tag you can append any HTML to the bottom of your page, add styles, or execute JavaScript. Note: You can replace content within the HTML with variables by putting a variable name in curly brackets like this {{PageUrl}}.',
@@ -945,7 +952,8 @@ class TagTest extends IntegrationTestCase
                                     'defaultValue' => 'bodyEnd',
                                     'type' => 'string',
                                     'uiControl' => 'select',
-                                    'uiControlAttributes' => [],
+                                    'uiControlAttributes' => [
+                                    ],
                                     'availableValues' => [
                                         'headStart' => 'Head Start',
                                         'headEnd' => 'Head End',

--- a/tests/System/expected/test_tag1__TagManager.getContainerTag.xml
+++ b/tests/System/expected/test_tag1__TagManager.getContainerTag.xml
@@ -47,6 +47,7 @@
 				<type>string</type>
 				<uiControl>textarea</uiControl>
 				<uiControlAttributes>
+					<spellcheck>false</spellcheck>
 				</uiControlAttributes>
 				<availableValues />
 				<description>This tag is ideal when you need to add for example custom styles or custom JavaScript or when you are looking for a specific tag which is not yet supported. With this tag you can append any HTML to the bottom of your page, add styles, or execute JavaScript. Note: You can replace content within the HTML with variables by putting a variable name in curly brackets like this {{PageUrl}}.</description>

--- a/tests/System/expected/test_tag2__TagManager.getContainerTag.xml
+++ b/tests/System/expected/test_tag2__TagManager.getContainerTag.xml
@@ -48,6 +48,7 @@
 				<type>string</type>
 				<uiControl>textarea</uiControl>
 				<uiControlAttributes>
+					<spellcheck>false</spellcheck>
 				</uiControlAttributes>
 				<availableValues />
 				<description>This tag is ideal when you need to add for example custom styles or custom JavaScript or when you are looking for a specific tag which is not yet supported. With this tag you can append any HTML to the bottom of your page, add styles, or execute JavaScript. Note: You can replace content within the HTML with variables by putting a variable name in curly brackets like this {{PageUrl}}.</description>

--- a/tests/System/expected/test_webContext__TagManager.getAvailableTagTypesInContext.xml
+++ b/tests/System/expected/test_webContext__TagManager.getAvailableTagTypesInContext.xml
@@ -1650,6 +1650,7 @@
 						<type>string</type>
 						<uiControl>textarea</uiControl>
 						<uiControlAttributes>
+							<spellcheck>false</spellcheck>
 						</uiControlAttributes>
 						<availableValues />
 						<description>This tag is ideal when you need to add for example custom styles or custom JavaScript or when you are looking for a specific tag which is not yet supported. With this tag you can append any HTML to the bottom of your page, add styles, or execute JavaScript. Note: You can replace content within the HTML with variables by putting a variable name in curly brackets like this {{PageUrl}}.</description>

--- a/tests/System/expected/test_with_content__TagManager.getContainerTags.xml
+++ b/tests/System/expected/test_with_content__TagManager.getContainerTags.xml
@@ -49,6 +49,7 @@
 					<type>string</type>
 					<uiControl>textarea</uiControl>
 					<uiControlAttributes>
+						<spellcheck>false</spellcheck>
 					</uiControlAttributes>
 					<availableValues />
 					<description>This tag is ideal when you need to add for example custom styles or custom JavaScript or when you are looking for a specific tag which is not yet supported. With this tag you can append any HTML to the bottom of your page, add styles, or execute JavaScript. Note: You can replace content within the HTML with variables by putting a variable name in curly brackets like this {{PageUrl}}.</description>
@@ -133,6 +134,7 @@
 					<type>string</type>
 					<uiControl>textarea</uiControl>
 					<uiControlAttributes>
+						<spellcheck>false</spellcheck>
 					</uiControlAttributes>
 					<availableValues />
 					<description>This tag is ideal when you need to add for example custom styles or custom JavaScript or when you are looking for a specific tag which is not yet supported. With this tag you can append any HTML to the bottom of your page, add styles, or execute JavaScript. Note: You can replace content within the HTML with variables by putting a variable name in curly brackets like this {{PageUrl}}.</description>


### PR DESCRIPTION
### Description:

Disable spellcheck for customHTML text box
Fixes: #PG-4001, #926

### Review

* [ ] [Functional review done](https://developer.matomo.org/guides/pull-request-reviews#functional-review-done)
* [ ] [Potential edge cases thought about](https://developer.matomo.org/guides/pull-request-reviews#potential-edge-cases-thought-about) (behavior of the code with strange input, with strange internal state or possible interactions with other Matomo subsystems)
* [ ] [Usability review done](https://developer.matomo.org/guides/pull-request-reviews#usability-review-done) (is anything maybe unclear or think about anything that would cause people to reach out to support)
* [ ] [Security review done](https://developer.matomo.org/guides/security-in-piwik#checklist)
* [ ] [Wording review done](https://developer.matomo.org/guides/pull-request-reviews#translations-wording-review-done)
* [ ] [Code review done](https://developer.matomo.org/guides/pull-request-reviews#code-review-done)
* [ ] [Tests were added if useful/possible](https://developer.matomo.org/guides/pull-request-reviews#tests-were-added-if-usefulpossible)
* [ ] [Reviewed for breaking changes](https://developer.matomo.org/guides/pull-request-reviews#reviewed-for-breaking-changes)
* [ ] [Developer changelog updated if needed](https://developer.matomo.org/guides/pull-request-reviews#developer-changelog-updated-if-needed)
* [ ] [Documentation added if needed](https://developer.matomo.org/guides/pull-request-reviews#documentation-added-if-needed)
* [ ] Existing documentation updated if needed
