### PR TITLE
make sure updates can run after bootstrap

### DIFF
--- a/Context/BaseContext.php
+++ b/Context/BaseContext.php
@@ -87,7 +87,10 @@ abstract class BaseContext
 
         $idSite = $container['idsite'];
         $idContainer = $container['idcontainer'];
-        $isTagFireLimitAllowedInPreviewMode = $container['isTagFireLimitAllowedInPreviewMode'] ? 1 : 0;
+        $isTagFireLimitAllowedInPreviewMode = 0;
+        if (isset($container['isTagFireLimitAllowedInPreviewMode'])) {
+          $isTagFireLimitAllowedInPreviewMode = $container['isTagFireLimitAllowedInPreviewMode'] ? 1 : 0;
+        }
         $idContainerVersion = $release['idcontainerversion'];
         $container['idcontainerversion'] = $idContainerVersion;
         $environment = $release['environment'];


### PR DESCRIPTION
### Description:

When Matomo bootstraps, it can stop the upgrade to 5.2.0 as the array 
key `$container['isTagFireLimitAllowedInPreviewMode'] `in some cases is accessed in Context/BaseContext.php.

The suggested patch sets `$isTagFireLimitAllowedInPreviewMode = 0` as default and checks if array key exists for `isTagFireLimitAllowedInPreviewMode`.

Fixes: #959 

### Review

* [x] [Functional review done](https://developer.matomo.org/guides/pull-request-reviews#functional-review-done)
* [x] [Potential edge cases thought about](https://developer.matomo.org/guides/pull-request-reviews#potential-edge-cases-thought-about) (behavior of the code with strange input, with strange internal state or possible interactions with other Matomo subsystems)
* [ ] [Usability review done](https://developer.matomo.org/guides/pull-request-reviews#usability-review-done) (is anything maybe unclear or think about anything that would cause people to reach out to support)
* [ ] [Security review done](https://developer.matomo.org/guides/security-in-piwik#checklist)
* [ ] [Wording review done](https://developer.matomo.org/guides/pull-request-reviews#translations-wording-review-done)
* [x] [Code review done](https://developer.matomo.org/guides/pull-request-reviews#code-review-done)
* [ ] [Tests were added if useful/possible](https://developer.matomo.org/guides/pull-request-reviews#tests-were-added-if-usefulpossible)
* [ ] [Reviewed for breaking changes](https://developer.matomo.org/guides/pull-request-reviews#reviewed-for-breaking-changes)
* [ ] [Developer changelog updated if needed](https://developer.matomo.org/guides/pull-request-reviews#developer-changelog-updated-if-needed)
* [ ] [Documentation added if needed](https://developer.matomo.org/guides/pull-request-reviews#documentation-added-if-needed)
* [ ] Existing documentation updated if needed
