### PR TITLE
Fixes etracker Ecommerce Debug Mode checkbox not working, #KB-1120

### DIFF
--- a/Template/Tag/EtrackerTag.php
+++ b/Template/Tag/EtrackerTag.php
@@ -204,7 +204,6 @@ class EtrackerTag extends BaseTag
             $this->makeSetting('etrackerTransactionDebugMode', false, FieldConfig::TYPE_BOOL, function (FieldConfig $field) use ($trackingType) {
                 $field->title = Piwik::translate('TagManager_EtrackerTagTransactionDebugModeTitle');
                 $field->title = 'etracker Ecommerce Debug Mode';
-                $field->customFieldComponent = self::FIELD_VARIABLE_COMPONENT;
                 $field->condition = 'trackingType == "transaction"';
             }),
             $this->makeSetting('etrackerAddToCartProduct', '', FieldConfig::TYPE_STRING, function (FieldConfig $field) use ($trackingType) {

--- a/tests/System/expected/test_webContext__TagManager.getAvailableTagTypesInContext.xml
+++ b/tests/System/expected/test_webContext__TagManager.getAvailableTagTypesInContext.xml
@@ -1365,10 +1365,6 @@
 						<introduction />
 						<condition>trackingType == &quot;transaction&quot;</condition>
 						<fullWidth>0</fullWidth>
-						<component>
-							<plugin>TagManager</plugin>
-							<name>FieldVariableTemplate</name>
-						</component>
 					</row>
 					<row>
 						<name>etrackerAddToCartProduct</name>


### PR DESCRIPTION
### Description:

Fixes etracker Ecommerce Debug Mode checkbox not working
Fixes: #KB-1120

The checkbox was set as a customField and hence it opened a modal to select variable, which made it unusable.

### Review

* [ ] [Functional review done](https://developer.matomo.org/guides/pull-request-reviews#functional-review-done)
* [ ] [Potential edge cases thought about](https://developer.matomo.org/guides/pull-request-reviews#potential-edge-cases-thought-about) (behavior of the code with strange input, with strange internal state or possible interactions with other Matomo subsystems)
* [ ] [Usability review done](https://developer.matomo.org/guides/pull-request-reviews#usability-review-done) (is anything maybe unclear or think about anything that would cause people to reach out to support)
* [ ] [Security review done](https://developer.matomo.org/guides/security-in-piwik#checklist)
* [ ] [Wording review done](https://developer.matomo.org/guides/pull-request-reviews#translations-wording-review-done)
* [ ] [Code review done](https://developer.matomo.org/guides/pull-request-reviews#code-review-done)
* [ ] [Tests were added if useful/possible](https://developer.matomo.org/guides/pull-request-reviews#tests-were-added-if-usefulpossible)
* [ ] [Reviewed for breaking changes](https://developer.matomo.org/guides/pull-request-reviews#reviewed-for-breaking-changes)
* [ ] [Developer changelog updated if needed](https://developer.matomo.org/guides/pull-request-reviews#developer-changelog-updated-if-needed)
* [ ] [Documentation added if needed](https://developer.matomo.org/guides/pull-request-reviews#documentation-added-if-needed)
* [ ] Existing documentation updated if needed
