### PR TITLE
Improve UI test css selector

### DIFF
--- a/tests/UI/TagManager_spec.js
+++ b/tests/UI/TagManager_spec.js
@@ -187,7 +187,7 @@ describe("TagManager", function () {
     it('should show the container detail when delete button is pressed', async function () {
         const pageElement = await page.$('.page');
         await page.evaluate(function(){
-          $('.card-content:eq(1) .icon-delete').click()
+          $('.sitesManagerList .card-content:eq(1) .icon-delete').click()
         });
         await page.waitForTimeout(250);
         await capture.modal(page, 'manageWebsitesDeleteAction');


### PR DESCRIPTION
## Description
In https://github.com/matomo-org/matomo/pull/23277 some changes to the markup of a modal are done.
This causes a UI test here to fail, as the used selector now selects the wrong element. This fixes the test again.
