### PR TITLE
Update label selectors to not rely on a specific field name or id

### DIFF
--- a/vue/src/TagmanagerTrackingCode/TagManagerTrackingCode.less
+++ b/vue/src/TagmanagerTrackingCode/TagManagerTrackingCode.less
@@ -14,16 +14,16 @@
     margin: 8px 0 0 0;
   }
 
-  label[for="containers"], label[for="environment"] {
-    top: -4px !important;
-  }
-
   .siteSelector {
     max-width: 100%;
   }
 
   .trackingCodeAdvancedOptions {
     margin-left: 20px;
+
+    label:not(.siteSelectorLabel) {
+      top: -4px;
+    }
 
     > .advance-option {
       margin: 1rem 0;


### PR DESCRIPTION
## Description
A small tweak to target advanced options dropdowns differently not to rely on their explicit names. This relates to core PR https://github.com/matomo-org/matomo/pull/23385 which would cause the IDs to be different and the styling would stop working.

## Issue No
n/a

## Steps to Replicate the Issue
Change the name of the dropdowns in tracking code advanced options (when choosing tracking code for a measurable using tag manager) and observe the labels get misaligned.

## Checklist
- [✔] Tested locally
- [✔] visual tests still passing
- [NA] Are all newly added texts included via translation?
- [NA] Are text sanitized properly? (Eg use of v-text v/s v-html for vue)
- [NA] Version bumped?