### PR TITLE
Fixes reference check not allowing import of same draft version, #PG-4532

### DIFF
--- a/API/Import.php
+++ b/API/Import.php
@@ -129,11 +129,11 @@ class Import
         }
 
         foreach ($this->triggers->getContainerTriggers($idSite, $idContainerVersion) as $trigger) {
-            $this->triggers->deleteContainerTrigger($idSite, $idContainerVersion, $trigger['idtrigger']);
+            $this->triggers->deleteContainerTrigger($idSite, $idContainerVersion, $trigger['idtrigger'], true);
         }
 
         foreach ($this->variables->getContainerVariables($idSite, $idContainerVersion) as $variable) {
-            $this->variables->deleteContainerVariable($idSite, $idContainerVersion, $variable['idvariable']);
+            $this->variables->deleteContainerVariable($idSite, $idContainerVersion, $variable['idvariable'], true);
         }
 
         $ecv = $exportedContainerVersion;

--- a/Model/Trigger.php
+++ b/Model/Trigger.php
@@ -127,9 +127,9 @@ class Trigger extends BaseModel
         return $references;
     }
 
-    public function deleteContainerTrigger($idSite, $idContainerVersion, $idTrigger)
+    public function deleteContainerTrigger($idSite, $idContainerVersion, $idTrigger, $skipReferenceCheck = false)
     {
-        if ($this->getTriggerReferences($idSite, $idContainerVersion, $idTrigger)) {
+        if (!$skipReferenceCheck && $this->getTriggerReferences($idSite, $idContainerVersion, $idTrigger)) {
             throw new \Exception(Piwik::translate('TagManager_ErrorTriggerNotRemovableAsInUse'));
         }
         $this->dao->deleteContainerTrigger($idSite, $idContainerVersion, $idTrigger, $this->getCurrentDateTime());

--- a/Model/Variable.php
+++ b/Model/Variable.php
@@ -351,9 +351,9 @@ class Variable extends BaseModel
         return $this->enrichVariables($variables);
     }
 
-    public function deleteContainerVariable($idSite, $idContainerVersion, $idVariable)
+    public function deleteContainerVariable($idSite, $idContainerVersion, $idVariable, $skipReferenceCheck = false)
     {
-        if ($this->getContainerVariableReferences($idSite, $idContainerVersion, $idVariable)) {
+        if (!$skipReferenceCheck && $this->getContainerVariableReferences($idSite, $idContainerVersion, $idVariable)) {
             throw new \Exception(Piwik::translate('TagManager_ErrorDeleteReferencedVariable'));
         }
         $this->dao->deleteContainerVariable($idSite, $idContainerVersion, $idVariable, $this->getCurrentDateTime());

--- a/tests/System/APITest.php
+++ b/tests/System/APITest.php
@@ -17,7 +17,6 @@ use Piwik\Plugins\TagManager\Context\WebContext;
 use Piwik\Plugins\TagManager\Model\Container\FixedIdGenerator;
 use Piwik\Plugins\TagManager\Model\Environment;
 use Piwik\Plugins\TagManager\Model\Salt;
-use Piwik\Plugins\TagManager\Template\Variable\ConstantVariable;
 use Piwik\Plugins\TagManager\Template\Variable\CustomJsFunctionVariable;
 use Piwik\Plugins\TagManager\tests\Fixtures\TagManagerFixture;
 use Piwik\Tests\Framework\Fixture;

--- a/tests/System/APITest.php
+++ b/tests/System/APITest.php
@@ -17,6 +17,8 @@ use Piwik\Plugins\TagManager\Context\WebContext;
 use Piwik\Plugins\TagManager\Model\Container\FixedIdGenerator;
 use Piwik\Plugins\TagManager\Model\Environment;
 use Piwik\Plugins\TagManager\Model\Salt;
+use Piwik\Plugins\TagManager\Template\Variable\ConstantVariable;
+use Piwik\Plugins\TagManager\Template\Variable\CustomJsFunctionVariable;
 use Piwik\Plugins\TagManager\tests\Fixtures\TagManagerFixture;
 use Piwik\Tests\Framework\Fixture;
 use Piwik\Tests\Framework\TestCase\SystemTestCase;
@@ -434,6 +436,22 @@ class APITest extends SystemTestCase
 
         $this->runAnyApiTest('TagManager.exportContainerVersion', 'import_overwrite_itself', $params, array('xmlFieldsToRemove' => $this->fieldsToRemove));
         $this->runAnyApiTest('TagManager.getContainer', 'import_overwrite_itself', $params, array('xmlFieldsToRemove' => $this->fieldsToRemove));
+    }
+
+    public function test_import_possible_to_overwrite_itself_with_referenced_variable()
+    {
+        $idSite = self::$fixture->idSite2;
+        $idContainer = self::$fixture->idContainer1;
+        self::$fixture->addContainerVariable($idSite, $idContainer, self::$fixture->idContainer1DraftVersion, 'Constant', 'Constant-Reference', ['constantValue' => 'test']);
+        self::$fixture->addContainerVariable($idSite, $idContainer, self::$fixture->idContainer1DraftVersion, CustomJsFunctionVariable::ID, 'Custom JavaScript Constant Ref', ['jsFunction' => 'function () { return &quot;{{Constant-Reference}}&quot;; }']);
+        $exportDraftContainer1 = API::getInstance()->exportContainerVersion($idSite, $idContainer);
+
+        API::getInstance()->importContainerVersion(json_encode($exportDraftContainer1), $idSite, $idContainer);
+
+        $params = array('token_auth' => Fixture::getTokenAuth(), 'idContainer' => $idContainer, 'idSite' => $idSite);
+
+        $this->runAnyApiTest('TagManager.exportContainerVersion', 'import_overwrite_itself_with_referenced_variable', $params, array('xmlFieldsToRemove' => $this->fieldsToRemove));
+        $this->runAnyApiTest('TagManager.getContainer', 'import_overwrite_itself_with_referenced_variable', $params, array('xmlFieldsToRemove' => $this->fieldsToRemove));
     }
 
     public function test_addSite_createsDefaultContainer()

--- a/tests/System/expected/test___TagManager.exportContainerVersion_import_overwrite_itself_with_referenced_variable.xml
+++ b/tests/System/expected/test___TagManager.exportContainerVersion_import_overwrite_itself_with_referenced_variable.xml
@@ -24,7 +24,7 @@
 	</version>
 	<tags>
 		<row>
-			<idtag>22</idtag>
+			<idtag>31</idtag>
 			<type>CustomHtml</type>
 			<name>My Tag 2</name>
 			<description>My Tag 2 description</description>
@@ -34,10 +34,10 @@
 				<htmlPosition>bodyEnd</htmlPosition>
 			</parameters>
 			<fire_trigger_ids>
-				<row>23</row>
+				<row>35</row>
 			</fire_trigger_ids>
 			<block_trigger_ids>
-				<row>24</row>
+				<row>36</row>
 			</block_trigger_ids>
 			<fire_limit>once_lifetime</fire_limit>
 			<priority>343</priority>
@@ -50,7 +50,7 @@
 			
 		</row>
 		<row>
-			<idtag>23</idtag>
+			<idtag>32</idtag>
 			<type>CustomHtml</type>
 			<name>My Tag 1</name>
 			<description />
@@ -60,7 +60,7 @@
 				<htmlPosition>bodyEnd</htmlPosition>
 			</parameters>
 			<fire_trigger_ids>
-				<row>23</row>
+				<row>35</row>
 			</fire_trigger_ids>
 			<block_trigger_ids>
 			</block_trigger_ids>
@@ -75,7 +75,7 @@
 			
 		</row>
 		<row>
-			<idtag>24</idtag>
+			<idtag>33</idtag>
 			<type>CustomImage</type>
 			<name>My Tag 3</name>
 			<description />
@@ -85,8 +85,8 @@
 				<cacheBusterEnabled>1</cacheBusterEnabled>
 			</parameters>
 			<fire_trigger_ids>
-				<row>24</row>
-				<row>25</row>
+				<row>36</row>
+				<row>37</row>
 			</fire_trigger_ids>
 			<block_trigger_ids>
 			</block_trigger_ids>
@@ -103,7 +103,7 @@
 	</tags>
 	<triggers>
 		<row>
-			<idtrigger>23</idtrigger>
+			<idtrigger>35</idtrigger>
 			<type>CustomEvent</type>
 			<name>My trigger1</name>
 			<description>My trigger1 description setting it to a very long description to show up in the UI clipped</description>
@@ -118,7 +118,7 @@
 			
 		</row>
 		<row>
-			<idtrigger>24</idtrigger>
+			<idtrigger>36</idtrigger>
 			<type>WindowLoaded</type>
 			<name>Mytrigger2</name>
 			<description />
@@ -137,7 +137,7 @@
 			
 		</row>
 		<row>
-			<idtrigger>25</idtrigger>
+			<idtrigger>37</idtrigger>
 			<type>DomReady</type>
 			<name>Mytrigger3</name>
 			<description />
@@ -151,7 +151,7 @@
 			
 		</row>
 		<row>
-			<idtrigger>26</idtrigger>
+			<idtrigger>38</idtrigger>
 			<type>CustomEvent</type>
 			<name>My trigger4</name>
 			<description />
@@ -168,7 +168,7 @@
 	</triggers>
 	<variables>
 		<row>
-			<idvariable>13</idvariable>
+			<idvariable>22</idvariable>
 			<type>DataLayer</type>
 			<name>My Var 1</name>
 			<description />
@@ -189,7 +189,7 @@
 			
 		</row>
 		<row>
-			<idvariable>14</idvariable>
+			<idvariable>23</idvariable>
 			<type>DataLayer</type>
 			<name>My Var 2</name>
 			<description />
@@ -205,7 +205,7 @@
 			
 		</row>
 		<row>
-			<idvariable>15</idvariable>
+			<idvariable>24</idvariable>
 			<type>DataLayer</type>
 			<name>My Var 3</name>
 			<description>My Var 3 description</description>
@@ -221,7 +221,7 @@
 			
 		</row>
 		<row>
-			<idvariable>16</idvariable>
+			<idvariable>25</idvariable>
 			<type>Constant</type>
 			<name>Constant-Reference</name>
 			<description />
@@ -237,7 +237,7 @@
 			
 		</row>
 		<row>
-			<idvariable>17</idvariable>
+			<idvariable>26</idvariable>
 			<type>CustomJsFunction</type>
 			<name>Custom JavaScript Constant Ref</name>
 			<description />

--- a/tests/System/expected/test___TagManager.exportContainerVersion_import_overwrite_itself_with_referenced_variable.xml
+++ b/tests/System/expected/test___TagManager.exportContainerVersion_import_overwrite_itself_with_referenced_variable.xml
@@ -1,0 +1,256 @@
+<?xml version="1.0" encoding="utf-8" ?>
+<result>
+	<idcontainer>aaacont1</idcontainer>
+	<idsite>2</idsite>
+	<context>web</context>
+	<name>Container1</name>
+	<description />
+	<ignoreGtmDataLayer>0</ignoreGtmDataLayer>
+	<activelySyncGtmDataLayer>0</activelySyncGtmDataLayer>
+	<isTagFireLimitAllowedInPreviewMode>0</isTagFireLimitAllowedInPreviewMode>
+	
+	
+	
+	
+	<revision>0</revision>
+	<version>
+		<name />
+		<description />
+		<revision>0</revision>
+		
+		
+		
+		
+	</version>
+	<tags>
+		<row>
+			<idtag>22</idtag>
+			<type>CustomHtml</type>
+			<name>My Tag 2</name>
+			<description>My Tag 2 description</description>
+			<status>active</status>
+			<parameters>
+				<customHtml>&lt;script&gt;&lt;/script&gt;</customHtml>
+				<htmlPosition>bodyEnd</htmlPosition>
+			</parameters>
+			<fire_trigger_ids>
+				<row>23</row>
+			</fire_trigger_ids>
+			<block_trigger_ids>
+				<row>24</row>
+			</block_trigger_ids>
+			<fire_limit>once_lifetime</fire_limit>
+			<priority>343</priority>
+			<fire_delay>1350</fire_delay>
+			<start_date>2017-01-02 03:04:05</start_date>
+			<end_date>2029-01-02 03:04:05</end_date>
+			
+			
+			
+			
+		</row>
+		<row>
+			<idtag>23</idtag>
+			<type>CustomHtml</type>
+			<name>My Tag 1</name>
+			<description />
+			<status>active</status>
+			<parameters>
+				<customHtml>&lt;p&gt;&lt;/p&gt;</customHtml>
+				<htmlPosition>bodyEnd</htmlPosition>
+			</parameters>
+			<fire_trigger_ids>
+				<row>23</row>
+			</fire_trigger_ids>
+			<block_trigger_ids>
+			</block_trigger_ids>
+			<fire_limit>unlimited</fire_limit>
+			<priority>999</priority>
+			<fire_delay>0</fire_delay>
+			<start_date />
+			<end_date />
+			
+			
+			
+			
+		</row>
+		<row>
+			<idtag>24</idtag>
+			<type>CustomImage</type>
+			<name>My Tag 3</name>
+			<description />
+			<status>active</status>
+			<parameters>
+				<customImageSrc>/plugins/tracking.png</customImageSrc>
+				<cacheBusterEnabled>1</cacheBusterEnabled>
+			</parameters>
+			<fire_trigger_ids>
+				<row>24</row>
+				<row>25</row>
+			</fire_trigger_ids>
+			<block_trigger_ids>
+			</block_trigger_ids>
+			<fire_limit>unlimited</fire_limit>
+			<priority>999</priority>
+			<fire_delay>0</fire_delay>
+			<start_date />
+			<end_date />
+			
+			
+			
+			
+		</row>
+	</tags>
+	<triggers>
+		<row>
+			<idtrigger>23</idtrigger>
+			<type>CustomEvent</type>
+			<name>My trigger1</name>
+			<description>My trigger1 description setting it to a very long description to show up in the UI clipped</description>
+			<parameters>
+				<eventName>foo</eventName>
+			</parameters>
+			<conditions>
+			</conditions>
+			
+			
+			
+			
+		</row>
+		<row>
+			<idtrigger>24</idtrigger>
+			<type>WindowLoaded</type>
+			<name>Mytrigger2</name>
+			<description />
+			<parameters>
+			</parameters>
+			<conditions>
+				<row>
+					<actual>ErrorUrl</actual>
+					<comparison>contains</comparison>
+					<expected>foo</expected>
+				</row>
+			</conditions>
+			
+			
+			
+			
+		</row>
+		<row>
+			<idtrigger>25</idtrigger>
+			<type>DomReady</type>
+			<name>Mytrigger3</name>
+			<description />
+			<parameters>
+			</parameters>
+			<conditions>
+			</conditions>
+			
+			
+			
+			
+		</row>
+		<row>
+			<idtrigger>26</idtrigger>
+			<type>CustomEvent</type>
+			<name>My trigger4</name>
+			<description />
+			<parameters>
+				<eventName>foo{{My Var 3}}bar{{My Var 2}}baz{{PageUrl}}yeah</eventName>
+			</parameters>
+			<conditions>
+			</conditions>
+			
+			
+			
+			
+		</row>
+	</triggers>
+	<variables>
+		<row>
+			<idvariable>13</idvariable>
+			<type>DataLayer</type>
+			<name>My Var 1</name>
+			<description />
+			<parameters>
+				<dataLayerName>fooBarName</dataLayerName>
+			</parameters>
+			<lookup_table>
+				<row>
+					<match_value>foo</match_value>
+					<comparison>equals</comparison>
+					<out_value>bar</out_value>
+				</row>
+			</lookup_table>
+			<default_value>10</default_value>
+			
+			
+			
+			
+		</row>
+		<row>
+			<idvariable>14</idvariable>
+			<type>DataLayer</type>
+			<name>My Var 2</name>
+			<description />
+			<parameters>
+				<dataLayerName>dataVarName</dataLayerName>
+			</parameters>
+			<lookup_table>
+			</lookup_table>
+			<default_value />
+			
+			
+			
+			
+		</row>
+		<row>
+			<idvariable>15</idvariable>
+			<type>DataLayer</type>
+			<name>My Var 3</name>
+			<description>My Var 3 description</description>
+			<parameters>
+				<dataLayerName>dataVarName</dataLayerName>
+			</parameters>
+			<lookup_table>
+			</lookup_table>
+			<default_value />
+			
+			
+			
+			
+		</row>
+		<row>
+			<idvariable>16</idvariable>
+			<type>Constant</type>
+			<name>Constant-Reference</name>
+			<description />
+			<parameters>
+				<constantValue>test</constantValue>
+			</parameters>
+			<lookup_table>
+			</lookup_table>
+			<default_value />
+			
+			
+			
+			
+		</row>
+		<row>
+			<idvariable>17</idvariable>
+			<type>CustomJsFunction</type>
+			<name>Custom JavaScript Constant Ref</name>
+			<description />
+			<parameters>
+				<jsFunction>function () { return &quot;{{Constant-Reference}}&quot;; }</jsFunction>
+			</parameters>
+			<lookup_table>
+			</lookup_table>
+			<default_value />
+			
+			
+			
+			
+		</row>
+	</variables>
+</result>

--- a/tests/System/expected/test___TagManager.exportContainerVersion_site_default_container.xml
+++ b/tests/System/expected/test___TagManager.exportContainerVersion_site_default_container.xml
@@ -24,7 +24,7 @@
 	</version>
 	<tags>
 		<row>
-			<idtag>31</idtag>
+			<idtag>34</idtag>
 			<type>Matomo</type>
 			<name>Matomo Analytics</name>
 			<description />
@@ -50,7 +50,7 @@
 				<areCustomDimensionsSticky>0</areCustomDimensionsSticky>
 			</parameters>
 			<fire_trigger_ids>
-				<row>35</row>
+				<row>39</row>
 			</fire_trigger_ids>
 			<block_trigger_ids>
 			</block_trigger_ids>
@@ -67,7 +67,7 @@
 	</tags>
 	<triggers>
 		<row>
-			<idtrigger>35</idtrigger>
+			<idtrigger>39</idtrigger>
 			<type>PageView</type>
 			<name>Pageview</name>
 			<description />
@@ -83,7 +83,7 @@
 	</triggers>
 	<variables>
 		<row>
-			<idvariable>20</idvariable>
+			<idvariable>27</idvariable>
 			<type>MatomoConfiguration</type>
 			<name>Matomo Configuration</name>
 			<description />

--- a/tests/System/expected/test___TagManager.getContainer_import_overwrite_itself_with_referenced_variable.xml
+++ b/tests/System/expected/test___TagManager.getContainer_import_overwrite_itself_with_referenced_variable.xml
@@ -1,0 +1,159 @@
+<?xml version="1.0" encoding="utf-8" ?>
+<result>
+	<idcontainer>aaacont1</idcontainer>
+	<idsite>2</idsite>
+	<context>web</context>
+	<name>Container1</name>
+	<description />
+	<ignoreGtmDataLayer>0</ignoreGtmDataLayer>
+	<activelySyncGtmDataLayer>0</activelySyncGtmDataLayer>
+	<isTagFireLimitAllowedInPreviewMode>0</isTagFireLimitAllowedInPreviewMode>
+	<status>active</status>
+	
+	
+	
+	
+	<versions>
+		<row>
+			<idcontainerversion>14</idcontainerversion>
+			<idcontainer>aaacont1</idcontainer>
+			<idsite>2</idsite>
+			<status>active</status>
+			<revision>5</revision>
+			<name>container1_v5</name>
+			<description>Version with linked variables</description>
+			
+			
+			
+			
+			<environments>
+				<row>staging</row>
+			</environments>
+		</row>
+		<row>
+			<idcontainerversion>12</idcontainerversion>
+			<idcontainer>aaacont1</idcontainer>
+			<idsite>2</idsite>
+			<status>active</status>
+			<revision>4</revision>
+			<name>container1_v4_reversioned</name>
+			<description>new version from an older version</description>
+			
+			
+			
+			
+			<environments>
+				<row>live</row>
+				<row>dev</row>
+			</environments>
+		</row>
+		<row>
+			<idcontainerversion>11</idcontainerversion>
+			<idcontainer>aaacont1</idcontainer>
+			<idsite>2</idsite>
+			<status>active</status>
+			<revision>3</revision>
+			<name>container1_v3</name>
+			<description>Version from draft with tags, triggers and variables</description>
+			
+			
+			
+			
+			<environments>
+			</environments>
+		</row>
+		<row>
+			<idcontainerversion>10</idcontainerversion>
+			<idcontainer>aaacont1</idcontainer>
+			<idsite>2</idsite>
+			<status>active</status>
+			<revision>2</revision>
+			<name>container1_v2</name>
+			<description>Version from draft with tags and triggers setting it to a very long description to show up in the UI clipped!!!</description>
+			
+			
+			
+			
+			<environments>
+			</environments>
+		</row>
+		<row>
+			<idcontainerversion>9</idcontainerversion>
+			<idcontainer>aaacont1</idcontainer>
+			<idsite>2</idsite>
+			<status>active</status>
+			<revision>1</revision>
+			<name>container1_v1</name>
+			<description>Version from draft with only triggers</description>
+			
+			
+			
+			
+			<environments>
+			</environments>
+		</row>
+	</versions>
+	<releases>
+		<row>
+			<idcontainerrelease>1</idcontainerrelease>
+			<idcontainer>aaacont1</idcontainer>
+			<idcontainerversion>12</idcontainerversion>
+			<idsite>2</idsite>
+			<status>active</status>
+			<environment>live</environment>
+			<release_login>superUserLogin</release_login>
+			
+			
+			<version_name>container1_v4_reversioned</version_name>
+		</row>
+		<row>
+			<idcontainerrelease>2</idcontainerrelease>
+			<idcontainer>aaacont1</idcontainer>
+			<idcontainerversion>12</idcontainerversion>
+			<idsite>2</idsite>
+			<status>active</status>
+			<environment>dev</environment>
+			<release_login>superUserLogin</release_login>
+			
+			
+			<version_name>container1_v4_reversioned</version_name>
+		</row>
+		<row>
+			<idcontainerrelease>3</idcontainerrelease>
+			<idcontainer>aaacont1</idcontainer>
+			<idcontainerversion>14</idcontainerversion>
+			<idsite>2</idsite>
+			<status>active</status>
+			<environment>staging</environment>
+			<release_login>superUserLogin</release_login>
+			
+			
+			<version_name>container1_v5</version_name>
+		</row>
+		<row>
+			<idcontainerrelease>4</idcontainerrelease>
+			<idcontainer>aaacont1</idcontainer>
+			<idcontainerversion>1</idcontainerversion>
+			<idsite>2</idsite>
+			<status>active</status>
+			<environment>preview</environment>
+			<release_login>superUserLogin</release_login>
+			
+			
+			<version_name />
+		</row>
+	</releases>
+	<draft>
+		<idcontainerversion>1</idcontainerversion>
+		<idcontainer>aaacont1</idcontainer>
+		<idsite>2</idsite>
+		<status>active</status>
+		<revision>0</revision>
+		<name />
+		<description />
+		
+		
+		
+		
+	</draft>
+</result>


### PR DESCRIPTION
## Description
Fixes reference check not allowing import of same draft version
Fixes: #1034 

## Issue No
#PG-4532

## Steps to Replicate the Issue
1. Go to TagManager
2. Select the container
3. Select versions
4. At bottom of the page click "Export draft"
5. Now import the same draft and it will not work
6. Checkout this PR and it should allow import.



## Checklist
- [✔] Tested locally or on demo2/demo3?
- [✔] New test case added/updated?
- [NA] Are all newly added texts included via translation?
- [NA] Are text sanitized properly? (Eg use of v-text v/s v-html for vue)
- [NA] Version bumped?