### PR TITLE
Code to ensure new parameter to restore draft is not show up in API listing page

### DIFF
--- a/API.php
+++ b/API.php
@@ -1446,9 +1446,10 @@ class API extends \Piwik\Plugin\API
      * @param int $idSite The id of the site the given container belongs to
      * @param string $idContainer  The id of a container, for example "6OMh6taM"
      * @param string $backupName   If specified, a backup of the current draft will be created under this version name.
+     * @param bool $_isDraftRestoreCall A boolean parameter to specify, if its a backup restore call to avoid nesting exception if backup version has errors
      * @return array
      */
-    public function importContainerVersion($exportedContainerVersion, $idSite, $idContainer, $backupName = '', $isDraftRestoreCall = false)
+    public function importContainerVersion($exportedContainerVersion, $idSite, $idContainer, $backupName = '', bool $_isDraftRestoreCall = false)
     {
         $this->accessValidator->checkWriteCapability($idSite);
         if (!Piwik::isUserHasCapability($idSite, PublishLiveContainer::ID)) {
@@ -1461,7 +1462,7 @@ class API extends \Piwik\Plugin\API
             throw new Exception(Piwik::translate('TagManager_ErrorContainerVersionDoesNotExist'));
         }
 
-        if (!$isDraftRestoreCall) {
+        if (!$_isDraftRestoreCall) {
             $draft = $this->exportContainerVersion($idSite, $idContainer);
             $exportedContainerVersion = Common::unsanitizeInputValue($exportedContainerVersion);
         }

--- a/API.php
+++ b/API.php
@@ -1484,7 +1484,7 @@ class API extends \Piwik\Plugin\API
         try {
             $this->import->importContainerVersion($exportedContainerVersion, $idSite, $idContainer, $idContainerVersion);
         } catch (Exception $e) {
-            if (!$isDraftRestoreCall && !empty($draft)) {
+            if (!$_isDraftRestoreCall && !empty($draft)) {
                 if (!empty($backupVersionId)) {
                     // Delete the backup container if created
                     $this->deleteContainerVersion($idSite, $idContainer, $backupVersionId);


### PR DESCRIPTION
## Description
Code to ensure new parameter to restore draft is not show up in API listing page

## Issue No
<!-- Mention the issue number this PR addresses. Use GitHub keywords like:
     - Fixes #123 (closes the issue when merged)
     - Resolves #123
     - Related to #123 (if it doesn’t close the issue)
     - JIRA ticket number, if no GitHub issue available
-->

## Steps to Replicate the Issue
1. <!-- Step 1: Describe the action taken. -->
2. <!-- Step 2: What was the expected result? -->
3. <!-- Step 3: What was the actual result? -->



## Checklist
- [✔] Tested locally or on demo2/demo3?
- [NA] New test case added/updated?
- [NA] Are all newly added texts included via translation?
- [NA] Are text sanitized properly? (Eg use of v-text v/s v-html for vue)
- [NA] Version bumped?