### PR TITLE
Do not remove default timeout in UI tests

### DIFF
--- a/tests/UI/ContainerDashboard_spec.js
+++ b/tests/UI/ContainerDashboard_spec.js
@@ -5,8 +5,6 @@
  * @license http://www.gnu.org/licenses/gpl-3.0.html GPL v3 or later
  */
 describe("ContainerDashboard", function () {
-    this.timeout(0);
-
     this.fixture = "Piwik\\Plugins\\TagManager\\tests\\Fixtures\\TagManagerFixture";
     this.optionsOverride = {
         'persist-fixture-data': false

--- a/tests/UI/ContainerTag_spec.js
+++ b/tests/UI/ContainerTag_spec.js
@@ -5,8 +5,6 @@
  * @license http://www.gnu.org/licenses/gpl-3.0.html GPL v3 or later
  */
 describe("ContainerTag", function () {
-    this.timeout(0);
-
     this.fixture = "Piwik\\Plugins\\TagManager\\tests\\Fixtures\\TagManagerTagUiFixture";
     this.optionsOverride = {
         'persist-fixture-data': false

--- a/tests/UI/ContainerTrigger_spec.js
+++ b/tests/UI/ContainerTrigger_spec.js
@@ -5,8 +5,6 @@
  * @license http://www.gnu.org/licenses/gpl-3.0.html GPL v3 or later
  */
 describe("ContainerTrigger", function () {
-    this.timeout(0);
-
     this.fixture = "Piwik\\Plugins\\TagManager\\tests\\Fixtures\\TagManagerFixture";
     this.optionsOverride = {
         'persist-fixture-data': false

--- a/tests/UI/ContainerVariable_spec.js
+++ b/tests/UI/ContainerVariable_spec.js
@@ -5,8 +5,6 @@
  * @license http://www.gnu.org/licenses/gpl-3.0.html GPL v3 or later
  */
 describe("ContainerVariable", function () {
-    this.timeout(0);
-
     this.fixture = "Piwik\\Plugins\\TagManager\\tests\\Fixtures\\TagManagerFixture";
     this.optionsOverride = {
         'persist-fixture-data': false

--- a/tests/UI/ContainerVersion_spec.js
+++ b/tests/UI/ContainerVersion_spec.js
@@ -5,8 +5,6 @@
  * @license http://www.gnu.org/licenses/gpl-3.0.html GPL v3 or later
  */
 describe("ContainerVersion", function () {
-    this.timeout(0);
-
     this.fixture = "Piwik\\Plugins\\TagManager\\tests\\Fixtures\\TagManagerFixture";
     this.optionsOverride = {
         'persist-fixture-data': false

--- a/tests/UI/Container_spec.js
+++ b/tests/UI/Container_spec.js
@@ -5,8 +5,6 @@
  * @license http://www.gnu.org/licenses/gpl-3.0.html GPL v3 or later
  */
 describe("Container", function () {
-    this.timeout(0);
-
     this.fixture = "Piwik\\Plugins\\TagManager\\tests\\Fixtures\\TagManagerFixture";
     this.optionsOverride = {
         'persist-fixture-data': false

--- a/tests/UI/TagManager_spec.js
+++ b/tests/UI/TagManager_spec.js
@@ -5,8 +5,6 @@
  * @license http://www.gnu.org/licenses/gpl-3.0.html GPL v3 or later
  */
 describe("TagManager", function () {
-    this.timeout(0);
-
     this.fixture = "Piwik\\Plugins\\TagManager\\tests\\Fixtures\\TagManagerFixture";
     this.optionsOverride = {
         'persist-fixture-data': false


### PR DESCRIPTION
## Description

In our code builds we have seen recently that sometime the CI pipeline is hanging when running various tests. This then blocks the job and times out after hours. Most likely this happens as many tests still have `timeout(0)` defined in the beginning, preventing the default timeout to apply and the tests to be abort after a certain time.
