### PR TITLE
UI tests - ContainerTrigger - fix flaky test

### DIFF
--- a/tests/UI/ContainerTrigger_spec.js
+++ b/tests/UI/ContainerTrigger_spec.js
@@ -284,6 +284,7 @@ describe("ContainerTrigger", function () {
         await page.evaluate(() => $('#destinationSite ul li:first').click());
         await page.waitForTimeout(250);
         pageWrap = await page.waitForSelector('div.ui-dialog.mtmCopyTrigger');
+        await page.mouse.move(-10, -10);
         expect(await pageWrap.screenshot()).to.matchImage('copy_trigger_site_selected');
     });
 

--- a/tests/UI/expected-screenshots/ContainerTrigger_copy_trigger_site_selected.png
+++ b/tests/UI/expected-screenshots/ContainerTrigger_copy_trigger_site_selected.png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:1d41c45ed9a2e80f5cbe412b125a48ab32dcbfb9eb0357f5debaa1b9f197a1ba
-size 27383
+oid sha256:08261caeaf12866d02df182002256bdbc6430c84d923dd15b84ce13547300470
+size 27419


### PR DESCRIPTION
### Description

Move the mouse outside of screen before taking a screenshot to avoid having hover/title effect triggered.

#### Examples

From a failing CI:

**ContainerTrigger_copy_trigger_site_selected.png**

| Processed | Expected |
|---|---|
|  <img width="540" height="458" alt="image" src="https://github.com/user-attachments/assets/6c4fa460-0bb6-41c9-848c-7ec8ec9ad1e6" /> | <img width="540" height="458" alt="image" src="https://github.com/user-attachments/assets/98cbece0-1f02-4b84-9496-ba86444d2013" /> |




## Checklist
- [NA] Tested locally or on demo2/demo3?
- [NA] New test case added/updated?
- [NA] Are all newly added texts included via translation?
- [NA] Are text sanitized properly? (Eg use of v-text v/s v-html for vue)
- [NA] Version bumped?
- [NA] I have understood, reviewed, and tested all AI outputs before use
- [NA] All AI instructions respect security, IP, and privacy rules
