### PR TITLE
fix mismatch between urlDecode lookup string

### DIFF
--- a/Template/Variable/CookieVariable.web.js
+++ b/Template/Variable/CookieVariable.web.js
@@ -14,7 +14,7 @@
             var cookiePattern = new RegExp('(^|;)[ ]*' + cookieName + '=([^;]*)');
             var cookieMatch = cookiePattern.exec(cookie);
 
-            if (parameters.get('uriDecode', false) && cookieMatch) {
+            if (parameters.get('urlDecode', false) && cookieMatch) {
                 return TagManager.url.decodeSafe(cookieMatch[2]);
             } else if (cookieMatch) {
                 return cookieMatch[2];

--- a/tests/javascript/index.php
+++ b/tests/javascript/index.php
@@ -1652,15 +1652,15 @@
 
             defaultParameters = {document: {cookie: 'mytest=foobar; loginbaz=' + encodeURIComponent('#343ö34:-44095$')}};
             defaultParameters.cookieName = buildVariable('loginbaz');
-            defaultParameters.uriDecode = buildVariable(false);
+            defaultParameters.urlDecode = buildVariable(false);
             strictEqual('%23343%C3%B634%3A-44095%24', resolveTemplateVariable(templateToTest, defaultParameters), 'returns last cookie, uriDecode disabled');
 
             defaultParameters.cookieName = buildVariable('loginbaz');
-            defaultParameters.uriDecode = buildVariable(true);
+            defaultParameters.urlDecode = buildVariable(true);
             strictEqual('#343ö34:-44095$', resolveTemplateVariable(templateToTest, defaultParameters), 'returns last cookie, uriDecode enabled');
 
             defaultParameters.cookieName =  buildVariable('notexisting');
-            defaultParameters.uriDecode = buildVariable(true);
+            defaultParameters.urlDecode = buildVariable(true);
             strictEqual(undefined, resolveTemplateVariable(templateToTest, defaultParameters), 'returns undefined when cookie does not exist, uriDecode enabled');
         });
 


### PR DESCRIPTION
## Description

Currently there is a mismatch between `Template/Variable/CookieVariable.php:20` and `Template/Variable/CookieVariable.web.js:17`, where the `urlDecode` setting is defined and subsequently looked up. The client-side code looks for `uriDecode` not `urlDecode`, and so the setting value is never retrieved correctly. 

## Checklist
- [✔] Tested locally or on demo2/demo3?
- [✖] New test case added/updated?
- [NA] Are all newly added texts included via translation?
- [NA] Are text sanitized properly? (Eg use of v-text v/s v-html for vue)
- [NA] Version bumped?
- [NA] I have understood, reviewed, and tested all AI outputs before use
- [NA] All AI instructions respect security, IP, and privacy rules
