### PR TITLE
Added code to disallow adding tags if no access to container version

### DIFF
--- a/API.php
+++ b/API.php
@@ -524,7 +524,7 @@ class API extends \Piwik\Plugin\API
     ) {
         $name = trim($this->decodeQuotes($name));
         $this->accessValidator->checkWriteCapability($idSite);
-        $this->containers->checkContainerVersionExists($idSite, $idContainer, $idContainerVersion);
+        $this->assertUserCanEditContainerVersion($idSite, $idContainer, $idContainerVersion);
 
         if ($this->tagsProvider->isCustomTemplate($type) && !Piwik::isUserHasCapability($idSite, PublishLiveContainer::ID)) {
             $this->accessValidator->checkUseCustomTemplatesCapability($idSite);
@@ -575,7 +575,7 @@ class API extends \Piwik\Plugin\API
     ) {
         $name = trim($this->decodeQuotes($name));
         $this->accessValidator->checkWriteCapability($idSite);
-        $this->containers->checkContainerVersionExists($idSite, $idContainer, $idContainerVersion);
+        $this->assertUserCanEditContainerVersion($idSite, $idContainer, $idContainerVersion);
 
         $tag = $this->tags->getContainerTag($idSite, $idContainerVersion, $idTag);
         if (!empty($tag) && $this->tagsProvider->isCustomTemplate($tag['type'])) {
@@ -601,7 +601,7 @@ class API extends \Piwik\Plugin\API
     public function deleteContainerTag($idSite, $idContainer, $idContainerVersion, $idTag)
     {
         $this->accessValidator->checkWriteCapability($idSite);
-        $this->containers->checkContainerVersionExists($idSite, $idContainer, $idContainerVersion);
+        $this->assertUserCanEditContainerVersion($idSite, $idContainer, $idContainerVersion);
 
         $tag = $this->getContainerTag($idSite, $idContainer, $idContainerVersion, $idTag);
         if ($tag) {
@@ -631,7 +631,7 @@ class API extends \Piwik\Plugin\API
     public function pauseContainerTag($idSite, $idContainer, $idContainerVersion, $idTag)
     {
         $this->accessValidator->checkWriteCapability($idSite);
-        $this->containers->checkContainerVersionExists($idSite, $idContainer, $idContainerVersion);
+        $this->assertUserCanEditContainerVersion($idSite, $idContainer, $idContainerVersion);
 
         $tag = $this->getContainerTag($idSite, $idContainer, $idContainerVersion, $idTag);
         if ($tag) {
@@ -665,7 +665,7 @@ class API extends \Piwik\Plugin\API
     public function resumeContainerTag($idSite, $idContainer, $idContainerVersion, $idTag)
     {
         $this->accessValidator->checkWriteCapability($idSite);
-        $this->containers->checkContainerVersionExists($idSite, $idContainer, $idContainerVersion);
+        $this->assertUserCanEditContainerVersion($idSite, $idContainer, $idContainerVersion);
 
         $tag = $this->getContainerTag($idSite, $idContainer, $idContainerVersion, $idTag);
         if ($tag) {
@@ -761,7 +761,7 @@ class API extends \Piwik\Plugin\API
     {
         $name = trim($this->decodeQuotes($name));
         $this->accessValidator->checkWriteCapability($idSite);
-        $this->containers->checkContainerVersionExists($idSite, $idContainer, $idContainerVersion);
+        $this->assertUserCanEditContainerVersion($idSite, $idContainer, $idContainerVersion);
 
         if ($this->triggersProvider->isCustomTemplate($type) && !Piwik::isUserHasCapability($idSite, PublishLiveContainer::ID)) {
             $this->accessValidator->checkUseCustomTemplatesCapability($idSite);
@@ -794,7 +794,7 @@ class API extends \Piwik\Plugin\API
     {
         $name = trim($this->decodeQuotes($name));
         $this->accessValidator->checkWriteCapability($idSite);
-        $this->containers->checkContainerVersionExists($idSite, $idContainer, $idContainerVersion);
+        $this->assertUserCanEditContainerVersion($idSite, $idContainer, $idContainerVersion);
 
         $trigger = $this->triggers->getContainerTrigger($idSite, $idContainerVersion, $idTrigger);
         if (!empty($trigger) && $this->triggersProvider->isCustomTemplate($trigger['type'])) {
@@ -821,7 +821,7 @@ class API extends \Piwik\Plugin\API
     public function deleteContainerTrigger($idSite, $idContainer, $idContainerVersion, $idTrigger)
     {
         $this->accessValidator->checkWriteCapability($idSite);
-        $this->containers->checkContainerVersionExists($idSite, $idContainer, $idContainerVersion);
+        $this->assertUserCanEditContainerVersion($idSite, $idContainer, $idContainerVersion);
 
         $trigger = $this->getContainerTrigger($idSite, $idContainer, $idContainerVersion, $idTrigger);
         if ($trigger) {
@@ -965,7 +965,7 @@ class API extends \Piwik\Plugin\API
     {
         $name = trim($this->decodeQuotes($name));
         $this->accessValidator->checkWriteCapability($idSite);
-        $this->containers->checkContainerVersionExists($idSite, $idContainer, $idContainerVersion);
+        $this->assertUserCanEditContainerVersion($idSite, $idContainer, $idContainerVersion);
 
         if ($this->variablesProvider->isCustomTemplate($type) && !Piwik::isUserHasCapability($idSite, PublishLiveContainer::ID)) {
             $this->accessValidator->checkUseCustomTemplatesCapability($idSite);
@@ -1019,7 +1019,7 @@ class API extends \Piwik\Plugin\API
     {
         $name = trim($this->decodeQuotes($name));
         $this->accessValidator->checkWriteCapability($idSite);
-        $this->containers->checkContainerVersionExists($idSite, $idContainer, $idContainerVersion);
+        $this->assertUserCanEditContainerVersion($idSite, $idContainer, $idContainerVersion);
 
         $variable = $this->variables->getContainerVariable($idSite, $idContainerVersion, $idVariable);
         if (!empty($variable) && $this->variablesProvider->isCustomTemplate($variable['type'])) {
@@ -1065,7 +1065,7 @@ class API extends \Piwik\Plugin\API
     public function deleteContainerVariable($idSite, $idContainer, $idContainerVersion, $idVariable)
     {
         $this->accessValidator->checkWriteCapability($idSite);
-        $this->containers->checkContainerVersionExists($idSite, $idContainer, $idContainerVersion);
+        $this->assertUserCanEditContainerVersion($idSite, $idContainer, $idContainerVersion);
 
         $variable = $this->getContainerVariable($idSite, $idContainer, $idContainerVersion, $idVariable);
         if ($variable) {
@@ -1179,6 +1179,8 @@ class API extends \Piwik\Plugin\API
 
         if (empty($idContainerVersion)) {
             $idContainerVersion = $this->getContainerDraftVersion($idSite, $idContainer);
+        } else {
+            $this->assertUserCanEditContainerVersion($idSite, $idContainer, $idContainerVersion);
         }
 
         $this->enableGeneratePreview = false;
@@ -1206,7 +1208,7 @@ class API extends \Piwik\Plugin\API
             $this->accessValidator->checkUseCustomTemplatesCapability($idSite);
         }
         BaseValidator::check(Piwik::translate('TagManager_VersionName'), $name, [new NotEmpty(), new CharacterLength(1, 50)]);
-        $this->containers->checkContainerVersionExists($idSite, $idContainer, $idContainerVersion);
+        $this->assertUserCanEditContainerVersion($idSite, $idContainer, $idContainerVersion);
 
         return $this->containers->updateContainerVersion($idSite, $idContainer, $idContainerVersion, $name, $description);
     }
@@ -1255,8 +1257,8 @@ class API extends \Piwik\Plugin\API
     public function deleteContainerVersion($idSite, $idContainer, $idContainerVersion)
     {
         $this->accessValidator->checkWriteCapability($idSite);
+        $this->assertUserCanEditContainerVersion($idSite, $idContainer, $idContainerVersion);
         $this->accessValidator->checkUseCustomTemplatesCapability($idSite);
-        $this->containers->checkContainerVersionExists($idSite, $idContainer, $idContainerVersion);
 
         if ($this->getContainerVersion($idSite, $idContainer, $idContainerVersion)) {
             $this->containers->deleteContainerVersion($idSite, $idContainer, $idContainerVersion);
@@ -1536,6 +1538,12 @@ class API extends \Piwik\Plugin\API
         if (!empty($containerVersion['draft']['idcontainerversion'])) {
             return $containerVersion['draft']['idcontainerversion'];
         }
+    }
+
+    private function assertUserCanEditContainerVersion($idSite, $idContainer, $idContainerVersion): void
+    {
+        $this->containers->checkContainerVersionExists($idSite, $idContainer, $idContainerVersion);
+        $this->accessValidator->checkWriteCapabilityForContainerVersion($idSite, $idContainer, $idContainerVersion);
     }
 
     private function decodeQuotes($value)

--- a/Input/AccessValidator.php
+++ b/Input/AccessValidator.php
@@ -14,6 +14,8 @@ use Piwik\NoAccessException;
 use Piwik\Plugins\TagManager\Access\Capability\PublishLiveContainer;
 use Piwik\Plugins\TagManager\Access\Capability\TagManagerWrite;
 use Piwik\Plugins\TagManager\Access\Capability\UseCustomTemplates;
+use Piwik\Plugins\TagManager\Dao\ContainerReleaseDao;
+use Piwik\Plugins\TagManager\Model\Environment;
 use Piwik\Piwik;
 use Piwik\Plugins\TagManager\SystemSettings;
 use Piwik\Site;
@@ -25,9 +27,15 @@ class AccessValidator
      */
     private $settings;
 
-    public function __construct(SystemSettings $settings)
+    /**
+     * @var ContainerReleaseDao|null
+     */
+    private $containerReleaseDao;
+
+    public function __construct(SystemSettings $settings, ?ContainerReleaseDao $containerReleaseDao = null)
     {
         $this->settings = $settings;
+        $this->containerReleaseDao = $containerReleaseDao;
     }
 
     public function checkViewPermission($idSite)
@@ -109,5 +117,28 @@ class AccessValidator
     public function checkSiteExists($idSite)
     {
         new Site($idSite);
+    }
+
+    public function checkWriteCapabilityForContainerVersion($idSite, $idContainer, $idContainerVersion)
+    {
+        if ($this->hasPublishLiveEnvironmentCapability($idSite)) {
+            return;
+        }
+
+        $releases = $this->getContainerReleaseDao()->getReleasesForContainerVersion($idSite, $idContainer, $idContainerVersion);
+        foreach ($releases as $release) {
+            if ($release['environment'] === Environment::ENVIRONMENT_LIVE) {
+                $this->checkPublishLiveEnvironmentCapability($idSite);
+            }
+        }
+    }
+
+    private function getContainerReleaseDao(): ContainerReleaseDao
+    {
+        if (!$this->containerReleaseDao) {
+            $this->containerReleaseDao = StaticContainer::get(ContainerReleaseDao::class);
+        }
+
+        return $this->containerReleaseDao;
     }
 }

--- a/tests/Integration/APITest.php
+++ b/tests/Integration/APITest.php
@@ -539,10 +539,8 @@ class APITest extends IntegrationTestCase
         $this->expectException(\Piwik\NoAccessException::class);
         $this->expectExceptionMessage('checkUserHasCapability tagmanager_publish_live_container Fake exception');
 
-        $variables = $this->api->getContainerVariables($this->idSite, $this->idContainer, $this->idLiveContainerVersion);
-
         $this->setWriteUser();
-        $this->api->deleteContainerVariable($this->idSite, $this->idContainer, $this->idLiveContainerVersion, $variables[0]['idvariable']);
+        $this->api->deleteContainerVariable($this->idSite, $this->idContainer, $this->idLiveContainerVersion, 999);
     }
 
     public function test_deleteContainerTrigger_shouldFailWhenNotHavingViewPermissions()

--- a/tests/Integration/APITest.php
+++ b/tests/Integration/APITest.php
@@ -41,6 +41,7 @@ class APITest extends IntegrationTestCase
     private $idContainer;
     private $idContainerQuotes;
     private $idContainerDraftVersion;
+    private $idLiveContainerVersion;
 
     /**
      * @var API
@@ -396,6 +397,15 @@ class APITest extends IntegrationTestCase
         $this->api->updateContainerVersion($this->idSite, $this->idContainer, $idContainerVersion, 'My Name very long!!!! name should throw an exception', 'TheName');
     }
 
+    public function test_updateContainerVersion_shouldFailWhenWriteUserTargetsLiveReleasedVersion()
+    {
+        $this->expectException(\Piwik\NoAccessException::class);
+        $this->expectExceptionMessage('checkUserHasCapability tagmanager_publish_live_container Fake exception');
+
+        $this->setWriteUser();
+        $this->api->updateContainerVersion($this->idSite, $this->idContainer, $this->idLiveContainerVersion, 'Renamed live version');
+    }
+
     public function test_createContainerVersion_shouldFailWhenNotHavingViewPermissions()
     {
         $this->expectException(\Piwik\NoAccessException::class);
@@ -421,6 +431,16 @@ class APITest extends IntegrationTestCase
 
         $this->setSuperUser();
         $this->api->createContainerVersion($this->idSite, $this->idContainer, 'My Name very long!!!! name should throw an exception');
+    }
+
+    public function test_createContainerVersion_shouldFailWhenWriteUserUsesLiveReleasedSourceVersion()
+    {
+        $this->expectException(\Piwik\NoAccessException::class);
+        $this->expectExceptionMessage('checkUserHasCapability tagmanager_publish_live_container Fake exception');
+
+        $this->setWriteUser();
+        FakeAccess::$idSitesCapabilities = array(UseCustomTemplates::ID => array($this->idSite));
+        $this->api->createContainerVersion($this->idSite, $this->idContainer, 'Copy of live version', '', $this->idLiveContainerVersion);
     }
 
     public function test_deleteContainerVersion_shouldFailWhenNotHavingViewPermissions()
@@ -513,6 +533,17 @@ class APITest extends IntegrationTestCase
         $this->api->deleteContainerVariable($this->idSite, $this->idContainer, $this->idContainerDraftVersion, $idVariable);
     }
 
+    public function test_deleteContainerVariable_shouldFailWhenWriteUserTargetsLiveReleasedVersion()
+    {
+        $this->expectException(\Piwik\NoAccessException::class);
+        $this->expectExceptionMessage('checkUserHasCapability tagmanager_publish_live_container Fake exception');
+
+        $variables = $this->api->getContainerVariables($this->idSite, $this->idContainer, $this->idLiveContainerVersion);
+
+        $this->setWriteUser();
+        $this->api->deleteContainerVariable($this->idSite, $this->idContainer, $this->idLiveContainerVersion, $variables[0]['idvariable']);
+    }
+
     public function test_deleteContainerTrigger_shouldFailWhenNotHavingViewPermissions()
     {
         $this->expectException(\Piwik\NoAccessException::class);
@@ -520,6 +551,17 @@ class APITest extends IntegrationTestCase
 
         $this->setUser();
         $this->api->deleteContainerTrigger($this->idSite, $this->idContainer, $this->idContainerDraftVersion, $idTrigger = 999);
+    }
+
+    public function test_deleteContainerTrigger_shouldFailWhenWriteUserTargetsLiveReleasedVersion()
+    {
+        $this->expectException(\Piwik\NoAccessException::class);
+        $this->expectExceptionMessage('checkUserHasCapability tagmanager_publish_live_container Fake exception');
+
+        $triggers = $this->api->getContainerTriggers($this->idSite, $this->idContainer, $this->idLiveContainerVersion);
+
+        $this->setWriteUser();
+        $this->api->deleteContainerTrigger($this->idSite, $this->idContainer, $this->idLiveContainerVersion, $triggers[0]['idtrigger']);
     }
 
     public function test_deleteContainerTrigger_shouldFailWhenVersionNotExists()
@@ -1342,6 +1384,7 @@ class APITest extends IntegrationTestCase
         $this->idContainer = $this->tagFixture->idContainer1;
         $this->idContainerQuotes = $this->tagFixture->idContainerQuotes;
         $this->idContainerDraftVersion = $this->tagFixture->idContainer1DraftVersion;
+        $this->idLiveContainerVersion = $this->tagFixture->idContainer1Version4;
 
         $this->api = API::getInstance();
 
@@ -1443,6 +1486,40 @@ class APITest extends IntegrationTestCase
         $id = $this->api->addContainerTag($this->idSite, $this->idContainer, $this->idContainerDraftVersion, CustomHtmlTag::ID, 'myName', array('customHtml' => 'foo'), $fireTrigger);
 
         $this->api->updateContainerTag($this->idSite, $this->idContainer, $this->idContainerDraftVersion, $id, 'myName2', array('customHtml' => 'foo'), $fireTrigger);
+    }
+
+    public function test_deleteContainerTag_shouldFailWhenWriteUserTargetsLiveReleasedVersion()
+    {
+        $this->expectException(\Piwik\NoAccessException::class);
+        $this->expectExceptionMessage('checkUserHasCapability tagmanager_publish_live_container Fake exception');
+
+        $tags = $this->api->getContainerTags($this->idSite, $this->idContainer, $this->idLiveContainerVersion);
+
+        $this->setWriteUser();
+        $this->api->deleteContainerTag($this->idSite, $this->idContainer, $this->idLiveContainerVersion, $tags[0]['idtag']);
+    }
+
+    public function test_enablePreviewMode_shouldAllowWriteUserForLiveReleasedVersion()
+    {
+        $this->setWriteUser();
+        $this->api->enablePreviewMode($this->idSite, $this->idContainer, $this->idLiveContainerVersion);
+
+        $container = $this->api->getContainer($this->idSite, $this->idContainer);
+        $this->assertNotEmpty($container['releases']);
+    }
+
+    public function test_updateContainerVersion_shouldSucceedWhenWriteUserHasPublishLiveCapability()
+    {
+        $this->setWriteUser();
+        FakeAccess::$idSitesCapabilities = array(
+            UseCustomTemplates::ID => array($this->idSite),
+            PublishLiveContainer::ID => array($this->idSite),
+        );
+
+        $this->api->updateContainerVersion($this->idSite, $this->idContainer, $this->idLiveContainerVersion, 'renamed by publish live');
+        $version = $this->api->getContainerVersion($this->idSite, $this->idContainer, $this->idLiveContainerVersion);
+
+        $this->assertSame('renamed by publish live', $version['name']);
     }
 
     protected function setSuperUser()

--- a/tests/Integration/APITest.php
+++ b/tests/Integration/APITest.php
@@ -403,6 +403,7 @@ class APITest extends IntegrationTestCase
         $this->expectExceptionMessage('checkUserHasCapability tagmanager_publish_live_container Fake exception');
 
         $this->setWriteUser();
+        FakeAccess::$idSitesCapabilities = array(UseCustomTemplates::ID => array($this->idSite));
         $this->api->updateContainerVersion($this->idSite, $this->idContainer, $this->idLiveContainerVersion, 'Renamed live version');
     }
 
@@ -458,7 +459,7 @@ class APITest extends IntegrationTestCase
         $this->expectExceptionMessage('checkUserHasCapability tagmanager_use_custom_templates Fake exception');
 
         $this->setAdminUser();
-        $this->api->deleteContainerVersion($this->idSite, 'foo', $this->idContainerDraftVersion);
+        $this->api->deleteContainerVersion($this->idSite, $this->idContainer, $this->idContainerDraftVersion);
     }
 
     public function test_createContainer_successEvenWhenDifferentSiteIdAddedInMatomoConfigurationVariable()

--- a/tests/Integration/Input/AccessValidatorTest.php
+++ b/tests/Integration/Input/AccessValidatorTest.php
@@ -13,6 +13,7 @@ use Piwik\Plugins\TagManager\Access\Capability\PublishLiveContainer;
 use Piwik\Plugins\TagManager\Access\Capability\TagManagerWrite;
 use Piwik\Plugins\TagManager\Input\AccessValidator;
 use Piwik\Plugins\TagManager\SystemSettings;
+use Piwik\Plugins\TagManager\tests\Fixtures\TagManagerFixture;
 use Piwik\Plugins\TagManager\tests\Framework\TestCase\IntegrationTestCase;
 use Piwik\Tests\Framework\Fixture;
 use Piwik\Tests\Framework\Mock\FakeAccess;
@@ -35,6 +36,11 @@ class AccessValidatorTest extends IntegrationTestCase
      */
     private $settings;
 
+    /**
+     * @var TagManagerFixture
+     */
+    private $tagFixture;
+
     public function setUp(): void
     {
         parent::setUp();
@@ -43,6 +49,9 @@ class AccessValidatorTest extends IntegrationTestCase
         $this->validator = new AccessValidator($this->settings);
 
         Fixture::createWebsite('2014-01-02 03:04:05');
+        $this->tagFixture = new TagManagerFixture();
+        $this->tagFixture->setUpWebsite();
+        $this->tagFixture->setUpContainers();
     }
 
     public function test_checkWriteCapability()
@@ -230,6 +239,44 @@ class AccessValidatorTest extends IntegrationTestCase
         $this->assertTrue($this->validator->hasWriteCapability($idSite = 1));
     }
 
+    public function test_checkWriteCapabilityForContainerVersion_allowsWriteUserForDraftVersion()
+    {
+        self::expectNotToPerformAssertions();
+
+        $this->setWrite();
+        $this->validator->checkWriteCapabilityForContainerVersion(
+            $this->tagFixture->idSite2,
+            $this->tagFixture->idContainer1,
+            $this->tagFixture->idContainer1DraftVersion
+        );
+    }
+
+    public function test_checkWriteCapabilityForContainerVersion_throwsForWriteUserWhenVersionReleasedToLive()
+    {
+        $this->expectException(\Exception::class);
+        $this->expectExceptionMessage('checkUserHasCapability tagmanager_publish_live_container Fake exception');
+
+        $this->setWrite();
+        $this->validator->checkWriteCapabilityForContainerVersion(
+            $this->tagFixture->idSite2,
+            $this->tagFixture->idContainer1,
+            $this->tagFixture->idContainer1Version4
+        );
+    }
+
+    public function test_checkWriteCapabilityForContainerVersion_allowsUserWithPublishLiveCapability()
+    {
+        self::expectNotToPerformAssertions();
+
+        $this->setWrite();
+        FakeAccess::$idSitesCapabilities = array(PublishLiveContainer::ID => array($this->tagFixture->idSite2));
+        $this->validator->checkWriteCapabilityForContainerVersion(
+            $this->tagFixture->idSite2,
+            $this->tagFixture->idContainer1,
+            $this->tagFixture->idContainer1Version4
+        );
+    }
+
     protected function setAnonymous()
     {
         FakeAccess::clearAccess(false);
@@ -251,7 +298,7 @@ class AccessValidatorTest extends IntegrationTestCase
         FakeAccess::clearAccess(false);
         FakeAccess::$identity = 'testUser';
         FakeAccess::$idSitesView = array();
-        FakeAccess::$idSitesWrite = array(1,3);
+        FakeAccess::$idSitesWrite = array(1,3, $this->tagFixture->idSite2);
         FakeAccess::$idSitesAdmin = array();
     }
 


### PR DESCRIPTION
## Description
Added code to disallow adding tags if no access to container version

## Issue No
#PG-5153

## Steps to Replicate the Issue
1. <!-- Step 1: Describe the action taken. -->
2. <!-- Step 2: What was the expected result? -->
3. <!-- Step 3: What was the actual result? -->



## Checklist
- [✔] Tested locally or on demo2/demo3?
- [✔] New test case added/updated?
- [NA] Are all newly added texts included via translation?
- [NA] Are text sanitized properly? (Eg use of v-text v/s v-html for vue)
- [NA] Version bumped?
- [✔] I have understood, reviewed, and tested all AI outputs before use
- [✔] All AI instructions respect security, IP, and privacy rules
- [NA] Documentation updated?
