### PR TITLE
Only regenerate containers on CoreUpdater.update.end, not every componentUpdated, #PG-5271

### DIFF
--- a/TagManager.php
+++ b/TagManager.php
@@ -59,7 +59,6 @@ class TagManager extends \Piwik\Plugin
             'PluginManager.pluginDeactivated' => 'onPluginActivateOrInstall',
             'PluginManager.pluginUninstalled' => 'onPluginActivateOrInstall',
             'TagManager.regenerateContainerReleases' => 'regenerateReleasedContainers',
-            'Updater.componentUpdated' => 'regenerateReleasedContainers',
             'Controller.CoreHome.checkForUpdates.end' => 'regenerateReleasedContainers',
             'CustomJsTracker.trackerJsChanged' => 'regenerateReleasedContainers', // in case a Matomo tracker is bundled
             'SitesManager.deleteSite.end' => 'onSiteDeleted',

--- a/tests/Integration/TagManagerTest.php
+++ b/tests/Integration/TagManagerTest.php
@@ -1,0 +1,49 @@
+<?php
+
+/**
+ * Matomo - free/libre analytics platform
+ *
+ * @link https://matomo.org
+ * @license http://www.gnu.org/licenses/gpl-3.0.html GPL v3 or later
+ */
+
+namespace Piwik\Plugins\TagManager\tests\Integration;
+
+use Piwik\Piwik;
+use Piwik\Plugins\TagManager\Context\BaseContext;
+use Piwik\Plugins\TagManager\tests\Fixtures\TagManagerFixture;
+use Piwik\Plugins\TagManager\tests\Framework\TestCase\IntegrationTestCase;
+
+/**
+ * @group TagManager
+ * @group TagManagerTest
+ * @group Plugins
+ */
+class TagManagerTest extends IntegrationTestCase
+{
+    /**
+     * @var TagManagerFixture
+     */
+    private $tagFixture;
+
+    public function setUp(): void
+    {
+        parent::setUp();
+
+        $this->tagFixture = new TagManagerFixture();
+        $this->tagFixture->setUpWebsite();
+        $this->tagFixture->setUpContainers();
+    }
+
+
+    public function test_CoreUpdaterUpdateEnd_regeneratesReleasedContainers()
+    {
+        $this->assertGreaterThan(0, BaseContext::removeAllFilesOfAllContainers());
+
+        $this->assertSame(0, BaseContext::removeAllFilesOfAllContainers());
+
+        Piwik::postEvent('CoreUpdater.update.end');
+
+        $this->assertGreaterThan(0, BaseContext::removeAllFilesOfAllContainers());
+    }
+}


### PR DESCRIPTION
## Description
<!-- Provide a brief but clear description of the changes introduced by this PR.
     Explain WHY the change was necessary and HOW it fixes the issue.
     If applicable, mention any dependencies or related changes. -->

Each time core fires `Updater.componentUpdated` (once per component), TagManager regenerates every container across every site. An upgrade like 5.11.0-b1 touches many components (core, several plugins, and one column-component per configured custom dimension), so that full regeneration runs dozens of times in a single update instead of once. The work is redundant and scales as components * containers * sites.

Removed event hook for `Updater.componentUpdated`, we now only call `regenerateReleasedContainers` on `CoreUpdater.update.end`


## Issue No
<!-- Mention the issue number this PR addresses. Use GitHub keywords like:
     - Fixes #123 (closes the issue when merged)
     - Resolves #123
     - Related to #123 (if it doesn’t close the issue)
     - JIRA ticket number, if no GitHub issue available
-->

## Steps to Replicate the Issue
1. <!-- Step 1: Describe the action taken. -->
2. <!-- Step 2: What was the expected result? -->
3. <!-- Step 3: What was the actual result? -->



## Checklist
- [✔] Tested locally or on demo2/demo3?
- [✔] New test case added/updated?
- [NA] Are all newly added texts included via translation?
- [NA] Are text sanitized properly? (Eg use of v-text v/s v-html for vue)
- [NA] Version bumped?
- [✔] I have understood, reviewed, and tested all AI outputs before use
- [✔] All AI instructions respect security, IP, and privacy rules
- [NA] Documentation updated?
