### PR TITLE
Improves container delete to check if its released and has permissions, #AS-593

### DIFF
--- a/API.php
+++ b/API.php
@@ -1307,6 +1307,9 @@ class API extends \Piwik\Plugin\API
     {
         $this->accessValidator->checkWriteCapability($idSite);
         $this->containers->checkContainerExists($idSite, $idContainer);
+        if ($this->containers->hasRelease($idSite, $idContainer, Environment::ENVIRONMENT_LIVE)) {
+            $this->accessValidator->checkPublishLiveEnvironmentCapability($idSite);
+        }
 
         $this->containers->deleteContainer($idSite, $idContainer);
         Piwik::postEvent('TagManager.deleteContainer.end', array(array(

--- a/Model/Container.php
+++ b/Model/Container.php
@@ -320,6 +320,15 @@ class Container extends BaseModel
         }
     }
 
+    public function hasRelease($idSite, $idContainer, $environment)
+    {
+        $this->checkContainerExists($idSite, $idContainer);
+
+        $release = $this->releasesDao->getReleaseForContainerVersion($idSite, $idContainer, $environment);
+
+        return !empty($release);
+    }
+
     public function publishVersion($idSite, $idContainer, $idContainerVersion, $environment, $releaseLogin)
     {
         $this->checkContainerVersionExists($idSite, $idContainer, $idContainerVersion);

--- a/tests/Integration/APITest.php
+++ b/tests/Integration/APITest.php
@@ -40,6 +40,7 @@ class APITest extends IntegrationTestCase
 
     private $idContainer;
     private $idContainerQuotes;
+    private $idContainerDraftOnly;
     private $idContainerDraftVersion;
     private $idLiveContainerVersion;
 
@@ -282,12 +283,12 @@ class APITest extends IntegrationTestCase
     public function test_deleteContainer_shouldSucceedWhenWriteUserTargetsDraftOnlyContainer()
     {
         $this->setWriteUser();
-        $this->api->deleteContainer($this->idSite, $this->idContainerQuotes);
+        $this->api->deleteContainer($this->idSite, $this->idContainerDraftOnly);
 
         $this->setAdminUser();
         $this->expectException(\Exception::class);
-        $this->expectExceptionMessage($this->idContainerQuotes);
-        $this->api->getContainer($this->idSite, $this->idContainerQuotes);
+        $this->expectExceptionMessage($this->idContainerDraftOnly);
+        $this->api->getContainer($this->idSite, $this->idContainerDraftOnly);
     }
 
     public function test_publishContainerVersion_shouldFailWhenNotHavingViewPermissions()
@@ -1402,6 +1403,7 @@ class APITest extends IntegrationTestCase
         $this->idSite = $this->tagFixture->idSite2;
         $this->idContainer = $this->tagFixture->idContainer1;
         $this->idContainerQuotes = $this->tagFixture->idContainerQuotes;
+        $this->idContainerDraftOnly = $this->tagFixture->idContainer3;
         $this->idContainerDraftVersion = $this->tagFixture->idContainer1DraftVersion;
         $this->idLiveContainerVersion = $this->tagFixture->idContainer1Version4;
 

--- a/tests/Integration/APITest.php
+++ b/tests/Integration/APITest.php
@@ -270,6 +270,26 @@ class APITest extends IntegrationTestCase
         $this->api->deleteContainer($this->idSite, $this->idContainer);
     }
 
+    public function test_deleteContainer_shouldFailWhenWriteUserTargetsLiveReleasedContainer()
+    {
+        $this->expectException(\Piwik\NoAccessException::class);
+        $this->expectExceptionMessage('checkUserHasCapability tagmanager_publish_live_container Fake exception');
+
+        $this->setWriteUser();
+        $this->api->deleteContainer($this->idSite, $this->idContainer);
+    }
+
+    public function test_deleteContainer_shouldSucceedWhenWriteUserTargetsDraftOnlyContainer()
+    {
+        $this->setWriteUser();
+        $this->api->deleteContainer($this->idSite, $this->idContainerQuotes);
+
+        $this->setAdminUser();
+        $this->expectException(\Exception::class);
+        $this->expectExceptionMessage($this->idContainerQuotes);
+        $this->api->getContainer($this->idSite, $this->idContainerQuotes);
+    }
+
     public function test_publishContainerVersion_shouldFailWhenNotHavingViewPermissions()
     {
         $this->expectException(\Piwik\NoAccessException::class);


### PR DESCRIPTION
## Description
Improves container delete to check if its released and has permissions

## Issue No
#AS-593


## Steps to Replicate the Issue
1. <!-- Step 1: Describe the action taken. -->
2. <!-- Step 2: What was the expected result? -->
3. <!-- Step 3: What was the actual result? -->



## Checklist
- [✔] Tested locally or on demo2/demo3?
- [✔] New test case added/updated?
- [NA] Are all newly added texts included via translation?
- [NA] Are text sanitized properly? (Eg use of v-text v/s v-html for vue)
- [NA] Version bumped?
- [✔] I have understood, reviewed, and tested all AI outputs before use
- [✔] All AI instructions respect security, IP, and privacy rules
- [NA] Documentation updated?
