### PR TITLE
Update UI screenshots for mainline matomo drift

### DIFF
--- a/tests/UI/expected-screenshots/ContainerVersion_mobile_tag_manager_left_menu.png
+++ b/tests/UI/expected-screenshots/ContainerVersion_mobile_tag_manager_left_menu.png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:d07ed5dc8d2c81519f23bf92699cb2addf7d0b271625dc8152b33348124af6d2
-size 5876
+oid sha256:49a9c4c80fd0da64362b782852469b05b0569e31dc9bf80e5469f525b16ca419
+size 5803

--- a/tests/UI/expected-screenshots/EmptySite_MTM_MultipleContainers_showAdvanced.png
+++ b/tests/UI/expected-screenshots/EmptySite_MTM_MultipleContainers_showAdvanced.png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:958157adca13221265aab57e4d57e0f596f62f55e99fa81601fed1cea8017f46
-size 149072
+oid sha256:ed71ac0565c7bf2129b357b72ee8b29ed2eb0ec3dd2c4f9ccc3d5c42542d1817
+size 150416


### PR DESCRIPTION
## Summary

Two expected screenshots have drifted against current mainline matomo (5.x-dev @ `ab73a90d93`, 2026-07-02). The submodule pointer `a4e54df1` last passed its own UI CI on 2026-06-29 — matomo core has moved since, causing sub-pixel rendering differences here.

Detected while restoring submodule UI test coverage in mainline matomo CI (see [matomo run 28563412709](https://github.com/matomo-org/matomo/actions/runs/28563412709), TagManager job: 227 passing, 2 failing). The other 227 TagManager screenshots still match.

## Files updated

| File | Diff | Note |
|---|---|---|
| `tests/UI/expected-screenshots/ContainerVersion_mobile_tag_manager_left_menu.png` | 251 pixels | Anti-aliasing shift, layout identical |
| `tests/UI/expected-screenshots/EmptySite_MTM_MultipleContainers_showAdvanced.png` | 40748 pixels | 1 px height reflow (927 → 926), content identical |

Both regenerated screenshots pulled from the failing run's processed artifacts:
`https://builds-artifacts.matomo.org/matomo-org/matomo/restore-submodule-ui-tests-in-plugin-matrix/28563412709/`

## Checklist
- [✔] Tested locally or on demo2/demo3?
- [✔] New test case added/updated?
- [NA] Are all newly added texts included via translation?
- [NA] Are text sanitized properly? (Eg use of v-text v/s v-html for vue)
- [NA] Version bumped?
- [✔] I have understood, reviewed, and tested all AI outputs before use
- [✔] All AI instructions respect security, IP, and privacy rules