### PR TITLE
Adds code to tighten the check for publish capability user, #PG-5347

### DIFF
--- a/API.php
+++ b/API.php
@@ -1187,9 +1187,9 @@ class API extends \Piwik\Plugin\API
         }
 
         $this->enableGeneratePreview = false;
-        $container = $this->accessValidator->runWithoutCustomTemplatesCapabilityCheck(
-            fn () => $this->containers->createContainerVersion($idSite, $idContainer, $idContainerVersion, $name, $description)
-        );
+        $container = $this->accessValidator->runWithoutCustomTemplatesCapabilityCheck(function () use ($idSite, $idContainer, $idContainerVersion, $name, $description) {
+            return $this->containers->createContainerVersion($idSite, $idContainer, $idContainerVersion, $name, $description);
+        });
         // not needed to create a preview release as no actual change to container was made. Make it faster as the createContainerVersion
         // uses "import" logic which would create a new preview release or check for recursions on every created tag/trigger/...
         $this->enableGeneratePreview = true;
@@ -1510,9 +1510,9 @@ class API extends \Piwik\Plugin\API
                     $this->deleteContainerVersion($idSite, $idContainer, $backupVersionId);
                 }
                 // rollback to old working draft
-                $this->accessValidator->runWithoutCustomTemplatesCapabilityCheck(
-                    fn () => $this->importContainerVersion(json_encode($draft, JSON_HEX_APOS), $idSite, $idContainer, '', true)
-                );
+                $this->accessValidator->runWithoutCustomTemplatesCapabilityCheck(function () use ($draft, $idSite, $idContainer) {
+                    $this->importContainerVersion(json_encode($draft, JSON_HEX_APOS), $idSite, $idContainer, '', true);
+                });
             }
             throw $e;
         }

--- a/API.php
+++ b/API.php
@@ -526,7 +526,7 @@ class API extends \Piwik\Plugin\API
         $this->accessValidator->checkWriteCapability($idSite);
         $this->assertUserCanEditContainerVersion($idSite, $idContainer, $idContainerVersion);
 
-        if ($this->tagsProvider->isCustomTemplate($type) && !Piwik::isUserHasCapability($idSite, PublishLiveContainer::ID)) {
+        if ($this->tagsProvider->isCustomTemplate($type)) {
             $this->accessValidator->checkUseCustomTemplatesCapability($idSite);
         }
 
@@ -763,7 +763,7 @@ class API extends \Piwik\Plugin\API
         $this->accessValidator->checkWriteCapability($idSite);
         $this->assertUserCanEditContainerVersion($idSite, $idContainer, $idContainerVersion);
 
-        if ($this->triggersProvider->isCustomTemplate($type) && !Piwik::isUserHasCapability($idSite, PublishLiveContainer::ID)) {
+        if ($this->triggersProvider->isCustomTemplate($type)) {
             $this->accessValidator->checkUseCustomTemplatesCapability($idSite);
         }
 
@@ -967,7 +967,7 @@ class API extends \Piwik\Plugin\API
         $this->accessValidator->checkWriteCapability($idSite);
         $this->assertUserCanEditContainerVersion($idSite, $idContainer, $idContainerVersion);
 
-        if ($this->variablesProvider->isCustomTemplate($type) && !Piwik::isUserHasCapability($idSite, PublishLiveContainer::ID)) {
+        if ($this->variablesProvider->isCustomTemplate($type)) {
             $this->accessValidator->checkUseCustomTemplatesCapability($idSite);
         }
 
@@ -1174,7 +1174,7 @@ class API extends \Piwik\Plugin\API
     {
         $name = $this->decodeQuotes($name);
         $this->accessValidator->checkWriteCapability($idSite);
-        if (!Piwik::isUserHasCapability($idSite, PublishLiveContainer::ID) && !Piwik::isUserHasCapability($idSite, PublishLiveContainer::ID)) {
+        if (!Piwik::isUserHasCapability($idSite, PublishLiveContainer::ID)) {
             $this->accessValidator->checkUseCustomTemplatesCapability($idSite);
         }
         $this->containers->checkContainerExists($idSite, $idContainer);
@@ -1187,7 +1187,9 @@ class API extends \Piwik\Plugin\API
         }
 
         $this->enableGeneratePreview = false;
-        $container = $this->containers->createContainerVersion($idSite, $idContainer, $idContainerVersion, $name, $description);
+        $container = $this->accessValidator->runWithoutCustomTemplatesCapabilityCheck(
+            fn () => $this->containers->createContainerVersion($idSite, $idContainer, $idContainerVersion, $name, $description)
+        );
         // not needed to create a preview release as no actual change to container was made. Make it faster as the createContainerVersion
         // uses "import" logic which would create a new preview release or check for recursions on every created tag/trigger/...
         $this->enableGeneratePreview = true;
@@ -1207,7 +1209,7 @@ class API extends \Piwik\Plugin\API
     {
         $name = $this->decodeQuotes($name);
         $this->accessValidator->checkWriteCapability($idSite);
-        if (!Piwik::isUserHasCapability($idSite, PublishLiveContainer::ID) && !Piwik::isUserHasCapability($idSite, PublishLiveContainer::ID)) {
+        if (!Piwik::isUserHasCapability($idSite, PublishLiveContainer::ID)) {
             $this->accessValidator->checkUseCustomTemplatesCapability($idSite);
         }
         BaseValidator::check(Piwik::translate('TagManager_VersionName'), $name, [new NotEmpty(), new CharacterLength(1, 50)]);
@@ -1508,7 +1510,9 @@ class API extends \Piwik\Plugin\API
                     $this->deleteContainerVersion($idSite, $idContainer, $backupVersionId);
                 }
                 // rollback to old working draft
-                $this->importContainerVersion(json_encode($draft, JSON_HEX_APOS), $idSite, $idContainer, '', true);
+                $this->accessValidator->runWithoutCustomTemplatesCapabilityCheck(
+                    fn () => $this->importContainerVersion(json_encode($draft, JSON_HEX_APOS), $idSite, $idContainer, '', true)
+                );
             }
             throw $e;
         }

--- a/API/Import.php
+++ b/API/Import.php
@@ -11,7 +11,6 @@ namespace Piwik\Plugins\TagManager\API;
 
 use Piwik\API\Request;
 use Piwik\Piwik;
-use Piwik\Plugins\TagManager\Access\Capability\PublishLiveContainer;
 use Piwik\Plugins\TagManager\Exception\EntityRecursionException;
 use Piwik\Plugins\TagManager\Input\AccessValidator;
 use Piwik\Plugins\TagManager\Model\Container;
@@ -98,7 +97,7 @@ class Import
         foreach ($exportedContainerVersion['tags'] as $tag) {
             $this->tagsProvider->checkIsValidTag($tag['type']);
 
-            if ($this->tagsProvider->isCustomTemplate($tag['type']) && !Piwik::isUserHasCapability($idSite, PublishLiveContainer::ID)) {
+            if ($this->tagsProvider->isCustomTemplate($tag['type'])) {
                 $this->accessValidator->checkUseCustomTemplatesCapability($idSite);
             }
         }
@@ -106,7 +105,7 @@ class Import
         foreach ($exportedContainerVersion['triggers'] as $trigger) {
             $this->triggersProvider->checkIsValidTrigger($trigger['type']);
 
-            if ($this->triggersProvider->isCustomTemplate($trigger['type']) && !Piwik::isUserHasCapability($idSite, PublishLiveContainer::ID)) {
+            if ($this->triggersProvider->isCustomTemplate($trigger['type'])) {
                 $this->accessValidator->checkUseCustomTemplatesCapability($idSite);
             }
         }
@@ -114,7 +113,7 @@ class Import
         foreach ($exportedContainerVersion['variables'] as $variable) {
             $this->variablesProvider->checkIsValidVariable($variable['type']);
 
-            if ($this->variablesProvider->isCustomTemplate($variable['type']) && !Piwik::isUserHasCapability($idSite, PublishLiveContainer::ID)) {
+            if ($this->variablesProvider->isCustomTemplate($variable['type'])) {
                 $this->accessValidator->checkUseCustomTemplatesCapability($idSite);
             }
         }

--- a/Controller.php
+++ b/Controller.php
@@ -493,6 +493,9 @@ class Controller extends \Piwik\Plugin\Controller
             $idDestinationSite = $request->getIntegerParameter('idDestinationSite');
             // Confirm tha the user has permission to copy to the selected site
             $this->accessValidator->checkWriteCapability($idDestinationSite);
+            // The copy imports the whole container version into the destination site, which may contain custom
+            // templates. Check the capability up front so we don't fail half way through the copy.
+            $this->accessValidator->checkUseCustomTemplatesCapability($idDestinationSite);
             $idContainer = $request->getStringParameter('idContainer');
 
             $idContainerNew = $this->container->copyContainer($this->idSite, $idContainer, $idDestinationSite);

--- a/Input/AccessValidator.php
+++ b/Input/AccessValidator.php
@@ -32,10 +32,26 @@ class AccessValidator
      */
     private $containerReleaseDao;
 
+    /**
+     * @var bool
+     */
+    private $skipCustomTemplatesCapabilityCheck = false;
+
     public function __construct(SystemSettings $settings, ?ContainerReleaseDao $containerReleaseDao = null)
     {
         $this->settings = $settings;
         $this->containerReleaseDao = $containerReleaseDao;
+    }
+
+    public function runWithoutCustomTemplatesCapabilityCheck(callable $callback)
+    {
+        $previous = $this->skipCustomTemplatesCapabilityCheck;
+        $this->skipCustomTemplatesCapabilityCheck = true;
+        try {
+            return $callback();
+        } finally {
+            $this->skipCustomTemplatesCapabilityCheck = $previous;
+        }
     }
 
     public function checkViewPermission($idSite)
@@ -61,6 +77,10 @@ class AccessValidator
 
     public function checkUseCustomTemplatesCapability($idSite)
     {
+        if ($this->skipCustomTemplatesCapabilityCheck) {
+            return;
+        }
+
         $this->checkSiteExists($idSite);
 
         if ($this->settings->restrictCustomTemplates->getValue() === SystemSettings::CUSTOM_TEMPLATES_SUPERUSER) {

--- a/Model/Container.php
+++ b/Model/Container.php
@@ -532,7 +532,13 @@ class Container extends BaseModel
 
         $exported = $this->getExport()->exportContainerVersion($idSite, $idContainer, $container['draft']['idcontainerversion']);
         $import = StaticContainer::get('Piwik\Plugins\TagManager\API\Import');
-        $import->importContainerVersion($exported, $idDestinationSite, $idContainerNew, $idContainerNewVersion);
+
+        try {
+            $import->importContainerVersion($exported, $idDestinationSite, $idContainerNew, $idContainerNewVersion);
+        } catch (Exception $e) {
+            $this->deleteContainer($idDestinationSite, $idContainerNew);
+            throw $e;
+        }
 
         // Make sure to record the activity for the report being copied
         if (class_exists('\Piwik\Plugins\ActivityLog\ActivityParamObject\EntityDuplicatedData')) {

--- a/tests/Integration/API/ImportTest.php
+++ b/tests/Integration/API/ImportTest.php
@@ -10,6 +10,7 @@
 namespace Piwik\Plugins\TagManager\tests\Integration;
 
 use Piwik\Container\StaticContainer;
+use Piwik\Plugins\TagManager\Access\Capability\PublishLiveContainer;
 use Piwik\Plugins\TagManager\API;
 use Piwik\Plugins\TagManager\Template\Tag\CustomHtmlTag;
 use Piwik\Plugins\TagManager\tests\Fixtures\TagManagerFixture;
@@ -105,6 +106,18 @@ class ImportTest extends IntegrationTestCase
         $this->expectExceptionMessage('checkUserHasCapability tagmanager_use_custom_templates');
 
         $this->setUser();
+        $this->exported['tags'][0]['type'] = CustomHtmlTag::ID;
+        $this->import->checkImportContainerIsPossible($this->exported, $this->idSite, $this->idContainer);
+    }
+
+    public function test_checkImportContainerIsPossible_shouldFailForPublishCapabilityWithoutCustomTemplatePermission()
+    {
+        // regression: the publish capability must NOT let a user import (author) a new custom template
+        $this->expectException(\Exception::class);
+        $this->expectExceptionMessage('checkUserHasCapability tagmanager_use_custom_templates');
+
+        $this->setUser();
+        FakeAccess::$idSitesCapabilities = array(PublishLiveContainer::ID => array($this->idSite));
         $this->exported['tags'][0]['type'] = CustomHtmlTag::ID;
         $this->import->checkImportContainerIsPossible($this->exported, $this->idSite, $this->idContainer);
     }

--- a/tests/Integration/APITest.php
+++ b/tests/Integration/APITest.php
@@ -1046,6 +1046,51 @@ class APITest extends IntegrationTestCase
         $this->api->addContainerTag($this->idSite, $this->idContainer, $this->idContainerDraftVersion, CustomHtmlTag::ID, 'myName');
     }
 
+    public function test_addContainerTag_shouldFailForPublishCapabilityWithoutCustomTemplatesCapability()
+    {
+        // regression: the publish capability must NOT let a user author a new custom template
+        $this->expectException(\Piwik\NoAccessException::class);
+        $this->expectExceptionMessage('checkUserHasCapability tagmanager_use_custom_templates Fake exception');
+
+        $this->setWriteUser();
+        FakeAccess::$idSitesCapabilities = array(PublishLiveContainer::ID => array($this->idSite));
+        $this->api->addContainerTag($this->idSite, $this->idContainer, $this->idContainerDraftVersion, CustomHtmlTag::ID, 'myName');
+    }
+
+    public function test_addContainerVariable_shouldFailForPublishCapabilityWithoutCustomTemplatesCapability()
+    {
+        // regression: the publish capability must NOT let a user author a new custom template
+        $this->expectException(\Piwik\NoAccessException::class);
+        $this->expectExceptionMessage('checkUserHasCapability tagmanager_use_custom_templates Fake exception');
+
+        $this->setWriteUser();
+        FakeAccess::$idSitesCapabilities = array(PublishLiveContainer::ID => array($this->idSite));
+        $this->api->addContainerVariable($this->idSite, $this->idContainer, $this->idContainerDraftVersion, CustomJsFunctionVariable::ID, 'myName');
+    }
+
+    public function test_createContainerVersion_publishCapabilityCanVersionContainerWithCustomTemplate()
+    {
+        // a publisher without the custom templates capability must still be able to create (and publish) a version
+        // of a container that already contains custom templates - the recreation is trusted, already-vetted content
+        $idTrigger = $this->test_addContainerTrigger_successRegularTemplateWithWriteUser();
+
+        $this->setAdminUser();
+        FakeAccess::$idSitesCapabilities = array(UseCustomTemplates::ID => array($this->idSite));
+        $this->api->addContainerTag($this->idSite, $this->idContainer, $this->idContainerDraftVersion, CustomHtmlTag::ID, 'myCustomHtml', array('customHtml' => 'foo'), array($idTrigger));
+
+        // switch to a publisher that does NOT hold the custom templates capability
+        $this->setWriteUser();
+        FakeAccess::$idSitesCapabilities = array(PublishLiveContainer::ID => array($this->idSite));
+
+        $idVersion = $this->api->createContainerVersion($this->idSite, $this->idContainer, 'v with custom html');
+        $this->assertNotEmpty($idVersion);
+
+        $version = $this->api->getContainerVersion($this->idSite, $this->idContainer, $idVersion);
+        $this->assertSame('v with custom html', $version['name']);
+
+        $this->api->publishContainerVersion($this->idSite, $this->idContainer, $idVersion, Environment::ENVIRONMENT_LIVE);
+    }
+
     public function test_updateContainerTag_shouldFailWhenNotHavingViewPermissions()
     {
         $this->expectException(\Piwik\NoAccessException::class);

--- a/tests/Integration/Model/ContainerCopyAccessTest.php
+++ b/tests/Integration/Model/ContainerCopyAccessTest.php
@@ -1,0 +1,178 @@
+<?php
+
+/**
+ * Matomo - free/libre analytics platform
+ *
+ * @link https://matomo.org
+ * @license http://www.gnu.org/licenses/gpl-3.0.html GPL v3 or later
+ */
+
+namespace Piwik\Plugins\TagManager\tests\Integration\Model;
+
+use Piwik\Container\StaticContainer;
+use Piwik\NoAccessException;
+use Piwik\Plugins\TagManager\Access\Capability\PublishLiveContainer;
+use Piwik\Plugins\TagManager\Access\Capability\UseCustomTemplates;
+use Piwik\Plugins\TagManager\Context\WebContext;
+use Piwik\Plugins\TagManager\Model\Container;
+use Piwik\Plugins\TagManager\Model\Tag;
+use Piwik\Plugins\TagManager\Model\Trigger;
+use Piwik\Plugins\TagManager\TagManager;
+use Piwik\Plugins\TagManager\Template\Tag\CustomHtmlTag;
+use Piwik\Plugins\TagManager\Template\Trigger\CustomEventTrigger;
+use Piwik\Plugins\TagManager\tests\Framework\Mock\FakeAccessTagManager;
+use Piwik\Plugins\TagManager\tests\Framework\TestCase\IntegrationTestCase;
+use Piwik\Tests\Framework\Fixture;
+use Piwik\Tests\Framework\Mock\FakeAccess;
+
+/**
+ * @group TagManager
+ * @group ContainerCopyAccessTest
+ * @group Container
+ * @group Plugins
+ */
+class ContainerCopyAccessTest extends IntegrationTestCase
+{
+    /**
+     * @var int
+     */
+    private $idSite;
+
+    /**
+     * @var int
+     */
+    private $idDestinationSite;
+
+    /**
+     * @var Container
+     */
+    private $model;
+
+    public function setUp(): void
+    {
+        parent::setUp();
+
+        TagManager::$enableAutoContainerCreation = false;
+
+        $this->setSuperUser();
+
+        $this->idSite = Fixture::createWebsite('2014-03-04 05:06:07');
+        $this->idDestinationSite = Fixture::createWebsite('2014-03-04 05:06:07');
+
+        $this->model = StaticContainer::get(Container::class);
+    }
+
+    public function tearDown(): void
+    {
+        $this->setSuperUser();
+        TagManager::$enableAutoContainerCreation = true;
+        parent::tearDown();
+    }
+
+    public function testCopyContainerToDifferentSiteFailsWhenMissingCustomTemplatesCapabilityOnDestinationSite()
+    {
+        $idContainer = $this->addContainerWithCustomTemplateTag();
+
+        $this->setPublisherWithoutCustomTemplatesCapability();
+
+        $this->expectException(NoAccessException::class);
+        $this->expectExceptionMessage('checkUserHasCapability tagmanager_use_custom_templates');
+
+        $this->model->copyContainer($this->idSite, $idContainer, $this->idDestinationSite);
+    }
+
+    public function testCopyContainerToDifferentSiteDoesNotLeaveContainerBehindWhenImportFails()
+    {
+        $idContainer = $this->addContainerWithCustomTemplateTag();
+
+        $this->setPublisherWithoutCustomTemplatesCapability();
+
+        try {
+            $this->model->copyContainer($this->idSite, $idContainer, $this->idDestinationSite);
+            $this->fail('copyContainer succeeded although the custom templates capability is missing on the destination site');
+        } catch (NoAccessException $e) {
+            // expected, the assertion below verifies the half finished copy was rolled back
+        }
+
+        $this->setSuperUser();
+        $this->assertSame(array(), $this->model->getContainers($this->idDestinationSite));
+    }
+
+    public function testCopyContainerToDifferentSiteSucceedsWithCustomTemplatesCapabilityOnBothSites()
+    {
+        $idContainer = $this->addContainerWithCustomTemplateTag();
+
+        $this->setPublisherWithoutCustomTemplatesCapability();
+        FakeAccess::$idSitesCapabilities[UseCustomTemplates::ID] = array($this->idSite, $this->idDestinationSite);
+
+        $idContainerCopy = $this->model->copyContainer($this->idSite, $idContainer, $this->idDestinationSite);
+        $this->assertNotEmpty($idContainerCopy);
+
+        $this->setSuperUser();
+        $containers = $this->model->getContainers($this->idDestinationSite);
+        $this->assertCount(1, $containers);
+
+        $containerCopy = $this->model->getContainer($this->idDestinationSite, $idContainerCopy);
+        $tag = StaticContainer::get(Tag::class);
+        $copiedTags = $tag->getContainerTags($this->idDestinationSite, $containerCopy['draft']['idcontainerversion']);
+        $this->assertCount(1, $copiedTags);
+        $this->assertSame(CustomHtmlTag::ID, $copiedTags[0]['type']);
+    }
+
+    private function addContainerWithCustomTemplateTag()
+    {
+        $idContainer = $this->model->addContainer($this->idSite, WebContext::ID, 'My Name', 'My Description', 0, 0, 0);
+
+        $container = $this->model->getContainer($this->idSite, $idContainer);
+        $idContainerVersion = $container['draft']['idcontainerversion'];
+
+        $trigger = StaticContainer::get(Trigger::class);
+        $idTrigger = $trigger->addContainerTrigger($this->idSite, $idContainerVersion, CustomEventTrigger::ID, 'My Trigger', array('eventName' => 'foo'), array());
+
+        $tag = StaticContainer::get(Tag::class);
+        $tag->addContainerTag(
+            $this->idSite,
+            $idContainerVersion,
+            CustomHtmlTag::ID,
+            'My Custom Html Tag',
+            array('customHtml' => '<p></p>'),
+            array($idTrigger),
+            array(),
+            Tag::FIRE_LIMIT_UNLIMITED,
+            0,
+            999,
+            null,
+            null
+        );
+
+        return $idContainer;
+    }
+
+    private function setSuperUser()
+    {
+        FakeAccess::clearAccess(true);
+    }
+
+    /**
+     * A user that may write to and publish on both sites, but that does not hold the custom templates capability
+     * on either of them.
+     */
+    private function setPublisherWithoutCustomTemplatesCapability()
+    {
+        FakeAccess::clearAccess(false);
+        FakeAccess::$identity = 'testUser';
+        FakeAccess::$idSitesView = array($this->idSite, $this->idDestinationSite);
+        FakeAccess::$idSitesWrite = array($this->idSite, $this->idDestinationSite);
+        FakeAccess::$idSitesAdmin = array();
+        FakeAccess::$idSitesCapabilities = array(
+            PublishLiveContainer::ID => array($this->idSite, $this->idDestinationSite),
+        );
+    }
+
+    public function provideContainerConfig()
+    {
+        return array(
+            'Piwik\Access' => new FakeAccessTagManager()
+        );
+    }
+}


### PR DESCRIPTION
## Description
Adds code to tighten the check for publish capability user

## Issue No
#PG-5347

## Steps to Replicate the Issue
1. Disallow CustomHTML tags creation if user has only published capability
2. The capability would still allow to create a new version with custom tags



## Checklist
- [✔] Tested locally or on demo2/demo3?
- [✔] New test case added/updated?
- [NA] Are all newly added texts included via translation?
- [NA] Are text sanitized properly? (Eg use of v-text v/s v-html for vue)
- [NA] Version bumped?
- [✔] I have understood, reviewed, and tested all AI outputs before use
- [✔] All AI instructions respect security, IP, and privacy rules
- [NA] Documentation updated?
