### PR TITLE
Improve help icons position on card hover

### DIFF
--- a/tests/UI/expected-screenshots/ContainerTag_copy_tag_success_hidden.png
+++ b/tests/UI/expected-screenshots/ContainerTag_copy_tag_success_hidden.png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:c6b2898d8f21b8a48465268488a7c1b5eb70a689398e99ec578279791044540c
-size 138135
+oid sha256:db97ab0c5dfac0e468d1721f423868b552a5f5bacb02e24604c66b4c62dd74ee
+size 138245

--- a/tests/UI/expected-screenshots/ContainerTrigger_copy_trigger_success_hidden.png
+++ b/tests/UI/expected-screenshots/ContainerTrigger_copy_trigger_success_hidden.png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:0e527f710421fc603b63634c40d8591157abe2287c0bfb853eaa2586e3090c2b
-size 119051
+oid sha256:ab9f97b739bb52e1d2e25823095e0fdd26b53d8f0f6e8a0cc965503290175c4c
+size 119036

--- a/tests/UI/expected-screenshots/ContainerVariable_copy_variable_success_hidden.png
+++ b/tests/UI/expected-screenshots/ContainerVariable_copy_variable_success_hidden.png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:7824f6cbb1a1238e9bd9a0afd591fc4fbfaab477d407eacc4e25e2d18c6a866e
-size 441092
+oid sha256:0e05ec37cde97e635f77d40e1f9c14dc5b06e7295fd7cafd745101773bf7acdd
+size 441036

--- a/tests/UI/expected-screenshots/ContainerVersion_confirm_delete_version_confirmed.png
+++ b/tests/UI/expected-screenshots/ContainerVersion_confirm_delete_version_confirmed.png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:7b6b2acb2afb419923ab425f2b9dfdf5f851460ecc3f9c4db362728388964087
-size 150933
+oid sha256:03e27da26545e73635ea60e3a131d4b9fb6e8098b76654dab5d6ee4f9d23e675
+size 151041


### PR DESCRIPTION
### Description

@Armanio noticed a slight jump when hovering over the icon and decided to contribute.

Before:

https://github.com/user-attachments/assets/559d86d8-bd27-454d-91aa-6e9c2aeda004


After:

https://github.com/user-attachments/assets/384bb729-2713-4bbd-af10-9e626c6563f3


## Issue No
<!-- Mention the issue number this PR addresses. Use GitHub keywords like:
     - Fixes #123 (closes the issue when merged)
     - Resolves #123
     - Related to #123 (if it doesn’t close the issue)
     - JIRA ticket number, if no GitHub issue available
-->

https://github.com/matomo-org/matomo/pull/24892



## Checklist
- [✔] Tested locally or on demo2/demo3?
- [NA] New test case added/updated?
- [NA] Are all newly added texts included via translation?
- [NA] Are text sanitized properly? (Eg use of v-text v/s v-html for vue)
- [NA] Version bumped?
- [NA] I have understood, reviewed, and tested all AI outputs before use
- [NA] All AI instructions respect security, IP, and privacy rules
- [NA] Documentation updated?
