### PR TITLE
Use native glob() instead of the _glob() wrapper

### DIFF
--- a/tests/javascript/head.php
+++ b/tests/javascript/head.php
@@ -17,8 +17,8 @@ $relativeRoot = '../../../..';
 
 function printTemplates($type)
 {
-    $files = \_glob(PIWIK_DOCUMENT_ROOT . '/plugins/*/Template/' . $type . '/*.web.js');
-    $files2 = \_glob(PIWIK_DOCUMENT_ROOT . '/plugins/*/Template/' . $type . '/*/*.web.js');
+    $files = glob(PIWIK_DOCUMENT_ROOT . '/plugins/*/Template/' . $type . '/*.web.js');
+    $files2 = glob(PIWIK_DOCUMENT_ROOT . '/plugins/*/Template/' . $type . '/*/*.web.js');
     $files = array_merge($files, $files2);
     foreach ($files as $file) {
         $name = str_replace('.web.js', '', basename($file));


### PR DESCRIPTION
## Description

Part of the Matomo 6 cleanup of `libs/upgradephp/upgrade.php` in core, which removes the obsolete PHP compatibility polyfills from that file.

One of them is the global `_glob()` wrapper. It existed to fall back to an `opendir()`/`readdir()` reimplementation when `glob()` was turned off via `disable_functions`. Matomo 6 no longer emulates that: `glob()` becomes a required function, checked at boot and in the system check. The core PR replaces all `_glob()` call sites with the native `glob()` and removes the wrapper, so this plugin's remaining call sites need the same change.

Only `tests/javascript/head.php` is affected. The behaviour is unchanged, since `_glob()` was already a plain pass-through to `glob()` whenever the latter existed.

A second commit falls back to an empty array when `glob()` fails, because `array_merge()` throws a `TypeError` on the `false` that `glob()` returns on error.

## Review

- [ ] Functional review
- [ ] Code review

### Checklist

- [✔] I have understood, reviewed, and tested all AI outputs before use
- [✔] All AI instructions respect security, IP, and privacy rules


