### PR TITLE
Fall back to an empty array when glob() fails

### DIFF
--- a/tests/javascript/head.php
+++ b/tests/javascript/head.php
@@ -17,8 +17,8 @@ $relativeRoot = '../../../..';
 
 function printTemplates($type)
 {
-    $files = glob(PIWIK_DOCUMENT_ROOT . '/plugins/*/Template/' . $type . '/*.web.js');
-    $files2 = glob(PIWIK_DOCUMENT_ROOT . '/plugins/*/Template/' . $type . '/*/*.web.js');
+    $files = glob(PIWIK_DOCUMENT_ROOT . '/plugins/*/Template/' . $type . '/*.web.js') ?: [];
+    $files2 = glob(PIWIK_DOCUMENT_ROOT . '/plugins/*/Template/' . $type . '/*/*.web.js') ?: [];
     $files = array_merge($files, $files2);
     foreach ($files as $file) {
         $name = str_replace('.web.js', '', basename($file));


### PR DESCRIPTION
## Description

Follow-up to #1149, which converted the two `_glob()` calls in `tests/javascript/head.php` to the native `glob()`.

`glob()` returns `false` on failure, and `array_merge()` throws a `TypeError` when given `false`. The results are merged on the next line, so a `glob()` failure would abort the JavaScript test harness with a fatal instead of simply producing no templates. `?: []` keeps the previous behaviour of continuing with an empty list.

This was spotted while reviewing the core PR matomo-org/matomo#24933 and is independent of it — nothing in core depends on this change.

## Review

- [ ] Functional review
- [ ] Code review

### Checklist
- [✔] I have understood, reviewed, and tested all AI outputs before use
- [✔] All AI instructions respect security, IP, and privacy rules