### PR TITLE
Update mobile left-menu screenshot for the core search-input restyle

### DIFF
--- a/tests/UI/expected-screenshots/ContainerVersion_mobile_tag_manager_left_menu.png
+++ b/tests/UI/expected-screenshots/ContainerVersion_mobile_tag_manager_left_menu.png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:44f17612143b9d0874eba4ec16a8dc0a61cc855ee59578bb9eece0711f100aef
-size 5138
+oid sha256:dda0937642f2a43337dec2236b5c498628e31b3ff8c17b90c99f00ada19b2264
+size 5130


### PR DESCRIPTION
Companion to matomo-org/matomo#24970.

The mobile tag-manager left-menu capture includes the core QuickAccess search box, whose icon was recolored (to `@theme-color-text-placeholder`) and vertically recentered by the core `.mtm-searchInput` change. This refreshes the single affected screenshot `ContainerVersion_mobile_tag_manager_left_menu.png`, regenerated from the core PR's GitHub Actions artifacts.

Based directly on `prepare6x`. Merge before the core PR so its submodule gitlink references a merged commit.