### PR TITLE
Update the view-access-restricted screenshot for the always-enabled s…

### DIFF
--- a/tests/UI/expected-screenshots/TagManager_view_access_restricted.png
+++ b/tests/UI/expected-screenshots/TagManager_view_access_restricted.png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:583d93def4171f6206f47383b508fc1cdd8705a40acd215916f8f0d904436364
-size 27943
+oid sha256:94da6ac3afe97dffc17a13ee3a178d748d721325a6f8fa634d54986831add4db
+size 28255


### PR DESCRIPTION
## Description
Update the view-access-restricted screenshot for the always-enabled sign in button

That page renders the login form, whose submit button is no longer disabled while the fields are empty, so this baseline captured the old grey button.


## Issue No
DEV-20463


## Checklist
- [✔] Tested locally or on demo2/demo3?
- [NA] New test case added/updated?
- [NA] Are all newly added texts included via translation?
- [NA] Are text sanitized properly? (Eg use of v-text v/s v-html for vue)
- [NA] Version bumped?
- [NA] I have understood, reviewed, and tested all AI outputs before use
- [NA] All AI instructions respect security, IP, and privacy rules
- [NA] Documentation updated?
