### PR TITLE
Update the general settings screenshots for the TrackingSpamPrevention core integration

### DIFF
--- a/tests/UI/expected-screenshots/TagManager_settings_page.png
+++ b/tests/UI/expected-screenshots/TagManager_settings_page.png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:e3e3d6ec8ba860c1d68610fbcacecf828559a45a0f937207603d4429b0c48a84
-size 115343
+oid sha256:5875c21e17e5c7270da90a0583a950297b0dbb1c43eb61b026ca4b0e5ca58858
+size 115342

--- a/tests/UI/expected-screenshots/TagManager_update_restrict_setting.png
+++ b/tests/UI/expected-screenshots/TagManager_update_restrict_setting.png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:f9847ee29afdd6d31fbd2585f45fc8db5b4ab7ceea351c7b617d076d8bd9f719
-size 115394
+oid sha256:f980c09ed58e5f9ef0416b404bbbb0cc6c0b75553c45d1bf6ad01cffccab705f
+size 115342

--- a/tests/UI/expected-screenshots/TagManager_view_access_restricted.png
+++ b/tests/UI/expected-screenshots/TagManager_view_access_restricted.png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:583d93def4171f6206f47383b508fc1cdd8705a40acd215916f8f0d904436364
-size 27943
+oid sha256:94da6ac3afe97dffc17a13ee3a178d748d721325a6f8fa634d54986831add4db
+size 28255


### PR DESCRIPTION
## Description

Updates the two general settings screenshots for the `TrackingSpamPrevention` core integration in matomo-org/matomo#25035.

With Matomo 6 that plugin is bundled with core and activated by default, so on `?module=CoreAdminHome&action=generalSettings` its settings card moves up in the plugin load order and shows the settings it gained since the previously pinned commit. Both screenshots in this plugin capture that page, so they change even though nothing in Tag Manager itself does.

Both images are taken from the matomo-org/matomo#25035 build artifacts, so they are exactly what CI renders, and this branch changes nothing besides them.

This has to be merged before matomo-org/matomo#25035, which pins the submodule to this branch.

## Issue No

Related to matomo-org/matomo#25035

## Steps to Replicate the Issue

1. Check out matomo-org/matomo#25035, which bundles `TrackingSpamPrevention` with core.
2. Run the Tag Manager UI tests. Expected: they pass. Actual: `TagManager_settings_page` and `TagManager_update_restrict_setting` differ, because the general settings page now renders the plugin's settings card in a different position and with more settings.

## Checklist
- [✔] Tested locally or on demo2/demo3?
- [NA] New test case added/updated?
- [NA] Are all newly added texts included via translation?
- [NA] Are text sanitized properly? (Eg use of v-text v/s v-html for vue)
- [NA] Version bumped?
- [✔] I have understood, reviewed, and tested all AI outputs before use
- [✔] All AI instructions respect security, IP, and privacy rules
- [NA] Documentation updated?
