### PR TITLE
Update the view-access-restricted screenshot for the always-enabled sign in button

### DIFF
--- a/tests/UI/expected-screenshots/TagManager_view_access_restricted.png
+++ b/tests/UI/expected-screenshots/TagManager_view_access_restricted.png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:fd0b76793053c8eea17c7f61b4de4165f0e4b9776fb9405f8faeba1cd3fc83c4
-size 29574
+oid sha256:16d0e3f76066b41f618a6010c6138ff0b889b573f644de17cb634547c877af20
+size 30003


### PR DESCRIPTION
Backport of #1158.

Core PR: matomo-org/matomo#25056

### Checklist

- [✔] I have understood, reviewed, and tested all AI outputs before use
- [✔] All AI instructions respect security, IP, and privacy rules
