### PR TITLE
Update the view-access-restricted screenshot for the refreshed login layout [ignore_release]

### DIFF
--- a/tests/UI/expected-screenshots/TagManager_view_access_restricted.png
+++ b/tests/UI/expected-screenshots/TagManager_view_access_restricted.png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:94da6ac3afe97dffc17a13ee3a178d748d721325a6f8fa634d54986831add4db
-size 28255
+oid sha256:17e6394e1f1f511860f5fb9cd2c5d413ffb4c58f385887427f159427826f46e9
+size 34027


### PR DESCRIPTION
## Description

Fixes the red UI build on `6.x-dev`: the view-access-restricted page uses the login layout, which was recently redesigned in core, so the expected screenshot `TagManager_view_access_restricted.png` no longer matches.

This extracts the already-regenerated screenshot from #1159 (commit 0ba538e4, credited to its author) so the branch can go green without waiting for that larger PR to be rebased. The image is byte-identical to the processed screenshot produced by the failing `6.x-dev` run ([build 31978674551](https://builds-artifacts.matomo.org/matomo-org/tag-manager/6.x-dev/31978674551/), sha256 matches the LFS oid), so no behaviour is affected — this is a test-expectation sync only.

## Issue No
Related to #1159

## Steps to Replicate the Issue
1. Run the UI test suite for TagManager against core `6.x-dev` (see the [failing run](https://github.com/matomo-org/tag-manager/actions/runs/31978674551/job/95241929847)).
2. Expected: all specs pass.
3. Actual: `should fail to load MTM for view user` fails because the expected screenshot predates the refreshed core login layout.

## Checklist
- [✖] Tested locally or on demo2/demo3?
- [NA] New test case added/updated?
- [NA] Are all newly added texts included via translation?
- [NA] Are text sanitized properly? (Eg use of v-text v/s v-html for vue)
- [NA] Version bumped?
- [✔] I have understood, reviewed, and tested all AI outputs before use
- [✔] All AI instructions respect security, IP, and privacy rules
- [NA] Documentation updated?
