### PR TITLE
Stop modal animation before capturing the delete-website confirmation

### DIFF
--- a/tests/UI/capture.js
+++ b/tests/UI/capture.js
@@ -5,6 +5,15 @@
  * @license http://www.gnu.org/licenses/gpl-3.0.html GPL v3 or later
  */
 
+// A CSS transition keeps repainting after the DOM has stopped changing, so waiting on the page cannot tell
+// whether the pixels have settled. The modal footer's scroll shadow is the one that bites: it is still fading
+// when the capture lands, which differs by a few thousand pixels between otherwise identical runs.
+exports.disableAnimations = async function (page) {
+  await page.webpage.addStyleTag({
+    content: '*, *::before, *::after { transition: none !important; animation: none !important; }',
+  });
+};
+
 // the first table row can for some reason can have height that varies randomly by 1px.
 // hardcoding to 78px here for screenshot tests.
 exports.setTableRowHeight = async function (page) {
@@ -59,6 +68,7 @@ exports.modal = async function (page, screenshotName, comparisonThreshold)
         });
     });
 
+    await exports.disableAnimations(page);
     await exports.setTableRowHeight(page);
     const image = comparisonThreshold
         ? { imageName: screenshotName, comparisonThreshold: comparisonThreshold }

--- a/tests/UI/expected-screenshots/TagManager_manageWebsitesDeleteAction.png
+++ b/tests/UI/expected-screenshots/TagManager_manageWebsitesDeleteAction.png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:9203330d293e29fdd8b77b3e3ac48cad49b88220961267cc29560df51f426412
-size 41254
+oid sha256:68fbb80048eea5ebed687904b866e454a0eba91bdbfdbb58881c85cf252617a2
+size 41270

--- a/tests/UI/expected-screenshots/TagManager_manageWebsitesDeleteAction.png
+++ b/tests/UI/expected-screenshots/TagManager_manageWebsitesDeleteAction.png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:68fbb80048eea5ebed687904b866e454a0eba91bdbfdbb58881c85cf252617a2
-size 41270
+oid sha256:9203330d293e29fdd8b77b3e3ac48cad49b88220961267cc29560df51f426412
+size 41254


### PR DESCRIPTION
## Description

`should show the container detail when delete button is pressed` fails on `6.x-dev` with an 8911 px difference. This started as a screenshot resync, on the assumption that #1161 had missed a capture after core [#25033](https://github.com/matomo-org/matomo/pull/25033). **That was wrong**, and the first version of this PR is reverted here.

Resyncing the baseline produced *exactly* the same 8911 px difference on the next run. Downloading both images and diffing them shows why: they are identical except for a soft gradient in a 742×70 band across the bottom — the Materialize modal footer's scroll shadow, captured part-way through its transition. The capture is non-deterministic, so no baseline can ever match it.

Waiting on the page does not help, because a CSS transition keeps repainting after the DOM has stopped changing: height and markup are already final while the shadow is still fading. So this stops animation outright before capturing, which is the same class of workaround `capture.js` already applies a few lines below, where Materialize's open animation does not advance under the newer headless Chrome and the modal has to be forced to its final position.

The helper is applied only in `capture.modal`, so nothing else changes its behaviour. The baseline is left exactly as it is on `6.x-dev`.

This cannot be reproduced locally without the UI harness, so this PR's own run is the verification. If the difference disappears, the capture was animation; if it comes back at 8911 px again, something other than the shadow is moving and the diff images are worth another look.

## Issue No

No separate issue — found while auditing the red `6.x-dev` builds ahead of Matomo 6.

## Steps to Replicate the Issue

1. Run the UI tests against Matomo `6.x-dev`.
2. Expected: `should show the container detail when delete button is pressed` passes consistently.
3. Actual: it fails at 8911 px, and still fails at exactly 8911 px after the baseline is resynced.

## Checklist
- [✖] Tested locally or on demo2/demo3?
- [✔] New test case added/updated?
- [NA] Are all newly added texts included via translation?
- [NA] Are text sanitized properly? (Eg use of v-text v/s v-html for vue)
- [NA] Version bumped?
- [✔] I have understood, reviewed, and tested all AI outputs before use
- [✔] All AI instructions respect security, IP, and privacy rules
- [NA] Documentation updated?
