### PR TITLE
Fix "URI-decode Cookie" option of the Cookie variable having no effect

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 ## Changelog
 
+0.2.11
+
+* Fixed the "URI-decode Cookie" option of the Cookie variable having no effect
+
 0.2.10 - 22/06/2026
 
 * Fixed issue where ecommerce object would break when null

--- a/Template/Variable/CookieVariable.web.js
+++ b/Template/Variable/CookieVariable.web.js
@@ -14,7 +14,7 @@
             var cookiePattern = new RegExp('(^|;)[ ]*' + cookieName + '=([^;]*)');
             var cookieMatch = cookiePattern.exec(cookie);
 
-            if (parameters.get('uriDecode', false) && cookieMatch) {
+            if (parameters.get('urlDecode', false) && cookieMatch) {
                 return TagManager.url.decodeSafe(cookieMatch[2]);
             } else if (cookieMatch) {
                 return cookieMatch[2];

--- a/tests/javascript/index.php
+++ b/tests/javascript/index.php
@@ -1655,16 +1655,16 @@
 
             defaultParameters = {document: {cookie: 'mytest=foobar; loginbaz=' + encodeURIComponent('#343ö34:-44095$')}};
             defaultParameters.cookieName = buildVariable('loginbaz');
-            defaultParameters.uriDecode = buildVariable(false);
-            strictEqual('%23343%C3%B634%3A-44095%24', resolveTemplateVariable(templateToTest, defaultParameters), 'returns last cookie, uriDecode disabled');
+            defaultParameters.urlDecode = buildVariable(false);
+            strictEqual('%23343%C3%B634%3A-44095%24', resolveTemplateVariable(templateToTest, defaultParameters), 'returns last cookie, urlDecode disabled');
 
             defaultParameters.cookieName = buildVariable('loginbaz');
-            defaultParameters.uriDecode = buildVariable(true);
-            strictEqual('#343ö34:-44095$', resolveTemplateVariable(templateToTest, defaultParameters), 'returns last cookie, uriDecode enabled');
+            defaultParameters.urlDecode = buildVariable(true);
+            strictEqual('#343ö34:-44095$', resolveTemplateVariable(templateToTest, defaultParameters), 'returns last cookie, urlDecode enabled');
 
             defaultParameters.cookieName =  buildVariable('notexisting');
-            defaultParameters.uriDecode = buildVariable(true);
-            strictEqual(undefined, resolveTemplateVariable(templateToTest, defaultParameters), 'returns undefined when cookie does not exist, uriDecode enabled');
+            defaultParameters.urlDecode = buildVariable(true);
+            strictEqual(undefined, resolveTemplateVariable(templateToTest, defaultParameters), 'returns undefined when cookie does not exist, urlDecode enabled');
         });
 
         test("Matomo TagManager Template FirstDirectoryVariable", function() {


### PR DESCRIPTION
## Description

Backport of the 6.x-dev fix (`65063e37`) to 5.x-dev. 5.x has the identical bug.

The Cookie variable's "URI-decode Cookie" option had no effect — an encoded cookie value was always returned raw, whether the option was on or off.

The web template read the setting under the wrong name. `Template/Variable/CookieVariable.web.js` called `parameters.get('uriDecode', false)`, but the setting is registered in PHP as `urlDecode` (`Template/Variable/CookieVariable.php:36`). The lookup therefore never found the parameter and always fell back to the `false` default, so `TagManager.url.decodeSafe()` was unreachable for cookie variables.

The bug was invisible to the test suite because `tests/javascript/index.php` set the same wrong key, so the assertions passed against the broken behaviour. Both the template lookup and the three QUnit assertions now use `urlDecode`.

No migration is needed for the fix to reach live containers: released containers are re-rendered by the hourly `Tasks::regenerateReleasedContainers` task and on plugin activate/update. The public setting name is unchanged, so `TagManager.getAvailableVariableTypesInContext` is unaffected.

## Issue No

PG-5475

## Steps to Replicate the Issue

1. Create a Cookie variable pointing at a cookie whose value is URI-encoded (e.g. `loginbaz=%23343%C3%B634%3A-44095%24`), and enable the "URI-decode Cookie" option. Preview or publish the container and inspect the resolved variable value.
2. Expected result: the decoded value `#343ö34:-44095$`.
3. Actual result: the raw encoded value `%23343%C3%B634%3A-44095%24` — the option is ignored entirely.

## Checklist
- [✔] Tested locally or on demo2/demo3?
- [✔] New test case added/updated? — the three existing Cookie variable assertions now use the real parameter name and are genuine regression coverage: with the production change reverted, the "urlDecode enabled" assertion fails.
- [NA] Are all newly added texts included via translation? — no texts added; `CookieVariableUrlDecodeTitle`/`Description` are untouched.
- [NA] Are text sanitized properly? (Eg use of v-text v/s v-html for vue) — no Vue or template output changed.
- [NA] Version bumped? — this plugin ships with core and has no `plugin.json`; a `0.2.11` CHANGELOG entry was added.
- [✔] I have understood, reviewed, and tested all AI outputs before use
- [✔] All AI instructions respect security, IP, and privacy rules
- [NA] Documentation updated? — internal parameter-name fix with no user-facing behaviour change beyond the option now working as documented.
