### PR TITLE
Point the UI specs at the relocated option list [ignore_release]

### DIFF
--- a/tests/UI/ContainerTag_spec.js
+++ b/tests/UI/ContainerTag_spec.js
@@ -243,15 +243,15 @@ describe("ContainerTag", function () {
           elem.scrollTop(elem.height())
         });
         await page.waitForTimeout(500);
-        await capture.modal(page, 'edit_trigger_directly_popup_list_level1');
+        await capture.modalWithOpenList(page, 'edit_trigger_directly_popup_list_level1');
     });
 
     it('should show the popup list level 2 completely visible', async function () {
-        await page.evaluate(() => $('.modal.open .expandableList .collection.firstLevel li.collection-item:eq(0) h4').click());
+        await page.evaluate(() => $('.expandableList:visible .collection.firstLevel li.collection-item:eq(0) h4').click());
         await page.waitForTimeout(100);
         await page.waitForNetworkIdle();
         await page.waitForTimeout(500);
-        await capture.modal(page, 'edit_trigger_directly_popup_list_level2');
+        await capture.modalWithOpenList(page, 'edit_trigger_directly_popup_list_level2');
         await page.evaluate(() => function() {
           $('.modal.open .modal-close')[0].click();
         });

--- a/tests/UI/ContainerTrigger_spec.js
+++ b/tests/UI/ContainerTrigger_spec.js
@@ -139,7 +139,7 @@ describe("ContainerTrigger", function () {
         await selectTriggerType('DomReady');
         await page.click('div.condition0 div.expandableSelector');
         await page.click('ul.firstLevel > li.collection-item:first-child');
-        await capture.page(page, 'select_variable_filter');
+        await capture.pageWithOpenList(page, 'select_variable_filter');
     });
 
     it('should be able to prefill trigger', async function () {

--- a/tests/UI/capture.js
+++ b/tests/UI/capture.js
@@ -46,17 +46,22 @@ exports.page = async function (page, screenshotName)
     await exports.selector(page, screenshotName, '.pageWrap,#notificationContainer,.navbar');
 };
 
+exports.pageWithOpenList = async function (page, screenshotName)
+{
+    await exports.selector(page, screenshotName, '.pageWrap,#notificationContainer,.navbar,.expandableSelector__list');
+};
+
 exports.notification = async function (page, screenshotName)
 {
     await exports.selector(page, screenshotName, '#notificationContainer');
 };
 
-exports.modal = async function (page, screenshotName, comparisonThreshold)
+async function settleOpenModal(page)
 {
     await page.waitForNetworkIdle();
     await page.waitForTimeout(500); // ensure animation is finished
 
-    pageWrap = await page.waitForSelector('.modal.open');
+    const modal = await page.waitForSelector('.modal.open');
 
     // Materialize's modal open-animation may not advance under the new headless Chrome, leaving stale
     // inline styles that offset the capture; settle the open modal to its final state before capturing.
@@ -70,8 +75,30 @@ exports.modal = async function (page, screenshotName, comparisonThreshold)
 
     await exports.disableAnimations(page);
     await exports.setTableRowHeight(page);
-    const image = comparisonThreshold
+
+    return modal;
+}
+
+function imageFor(screenshotName, comparisonThreshold)
+{
+    return comparisonThreshold
         ? { imageName: screenshotName, comparisonThreshold: comparisonThreshold }
         : screenshotName;
-    expect(await pageWrap.screenshot()).to.matchImage(image);
+}
+
+exports.modal = async function (page, screenshotName, comparisonThreshold)
+{
+    const modal = await settleOpenModal(page);
+
+    expect(await modal.screenshot()).to.matchImage(imageFor(screenshotName, comparisonThreshold));
+};
+
+// An expandable select renders its list at the page level so it is not clipped by the modal, which
+// also puts it outside a screenshot of the modal element; both have to be named to stay in shot.
+exports.modalWithOpenList = async function (page, screenshotName, comparisonThreshold)
+{
+    await settleOpenModal(page);
+
+    expect(await page.screenshotSelector('.modal.open,.expandableSelector__list'))
+        .to.matchImage(imageFor(screenshotName, comparisonThreshold));
 };


### PR DESCRIPTION
## Description

Matomo core is changing the expandable select so its option list is rendered at the page level rather than inside the field, which stops a modal or any other scrolling container from clipping a long list (matomo-org/matomo#25225). Three UI specs here depend on the old placement and fail against that change.

`ContainerTag_spec.js` reached the list through `.modal.open`, which now matches nothing, so the click silently did nothing and the level 2 list never opened. The popup list specs also capture with `capture.modal()`, and `capture.page()` is used for the variable filter — both are screenshots of a single element, so neither can contain a list that is rendered outside it. Since those specs exist precisely to show the list is fully visible, they now name the list alongside the modal or page.

This is test-only, and it has to land together with the core change rather than ahead of it. Capturing the modal by a page region rather than as an element does not frame it identically, because the modal is a positioned overlay, so the two popup list screenshots change even before the list moves. They have to change in any case once it does: the list is then rendered outside the modal, and that is the whole subject of those two shots. Both baselines need regenerating against the core change, so this is held until then.

## Issue No

Related to matomo-org/matomo#25225

## Steps to Replicate the Issue

1. Run the TagManager UI tests against matomo-org/matomo#25225.
2. Expected: the popup list specs pass and show the option list.
3. Actual, before this change: `should show the popup list level 1/2 completely visible` and `should show list of available variables with description tooltips` fail, the first two with very large image diffs because the list is missing from the capture entirely.

## Checklist
- [✖] Tested locally or on demo2/demo3?
- [✔] New test case added/updated?
- [NA] Are all newly added texts included via translation?
- [NA] Are text sanitized properly? (Eg use of v-text v/s v-html for vue)
- [NA] Version bumped?
- [✔] I have understood, reviewed, and tested all AI outputs before use
- [✔] All AI instructions respect security, IP, and privacy rules
- [NA] Documentation updated?

